### PR TITLE
Fix ‘log2f’ was not declared in this scope

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/JitRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitRegCache.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <cinttypes>
+#include <cmath>
 
 #include "Core/PowerPC/Jit64/Jit.h"
 #include "Core/PowerPC/Jit64/JitAsm.h"


### PR DESCRIPTION
Add #include <cmath> for the prevent log2f whas no declared

Fix  JitRegCache.cpp:125:55: error: ‘log2f’ was not declared in this scope