### PR TITLE
libretro: add two efb hack options

### DIFF
--- a/Source/Core/DolphinLibretro/Boot.cpp
+++ b/Source/Core/DolphinLibretro/Boot.cpp
@@ -101,6 +101,7 @@ bool retro_load_game(const struct retro_game_info* game)
   Config::SetBase(Config::GFX_SHADER_COMPILATION_MODE, Libretro::Options::shaderCompilationMode);
   Config::SetBase(Config::GFX_ENHANCE_MAX_ANISOTROPY, Libretro::Options::maxAnisotropy);
   Config::SetBase(Config::GFX_HACK_COPY_EFB_SCALED, Libretro::Options::efbScaledCopy);
+  Config::SetBase(Config::GFX_HACK_SKIP_EFB_COPY_TO_RAM, Libretro::Options::efbToTexture);
   Config::SetBase(Config::GFX_ENABLE_GPU_TEXTURE_DECODING, Libretro::Options::gpuTextureDecoding);
   Config::SetBase(Config::GFX_WAIT_FOR_SHADERS_BEFORE_STARTING, Libretro::Options::waitForShaders);
 #if 0

--- a/Source/Core/DolphinLibretro/Boot.cpp
+++ b/Source/Core/DolphinLibretro/Boot.cpp
@@ -102,6 +102,7 @@ bool retro_load_game(const struct retro_game_info* game)
   Config::SetBase(Config::GFX_ENHANCE_MAX_ANISOTROPY, Libretro::Options::maxAnisotropy);
   Config::SetBase(Config::GFX_HACK_COPY_EFB_SCALED, Libretro::Options::efbScaledCopy);
   Config::SetBase(Config::GFX_HACK_SKIP_EFB_COPY_TO_RAM, Libretro::Options::efbToTexture);
+  Config::SetBase(Config::GFX_HACK_DISABLE_COPY_TO_VRAM, Libretro::Options::efbToVram);
   Config::SetBase(Config::GFX_ENABLE_GPU_TEXTURE_DECODING, Libretro::Options::gpuTextureDecoding);
   Config::SetBase(Config::GFX_WAIT_FOR_SHADERS_BEFORE_STARTING, Libretro::Options::waitForShaders);
 #if 0

--- a/Source/Core/DolphinLibretro/Options.cpp
+++ b/Source/Core/DolphinLibretro/Options.cpp
@@ -212,6 +212,7 @@ Option<ShaderCompilationMode> shaderCompilationMode(
      {"a-sync UberShaders", ShaderCompilationMode::AsynchronousUberShaders}});
 Option<int> maxAnisotropy("dolphin_max_anisotropy", "Max Anisotropy", 0, 17);
 Option<bool> efbScaledCopy("dolphin_efb_scaled_copy", "Scaled EFB Copy", true);
+Option<bool> efbToTexture("dolphin_efb_to_texture", "Store EFB Copies on GPU", true);
 Option<bool> gpuTextureDecoding("dolphin_gpu_texture_decoding", "GPU Texture Decoding", false);
 Option<bool> waitForShaders("dolphin_wait_for_shaders", "Wait for Shaders before Starting", false);
 }  // namespace Options

--- a/Source/Core/DolphinLibretro/Options.cpp
+++ b/Source/Core/DolphinLibretro/Options.cpp
@@ -213,6 +213,7 @@ Option<ShaderCompilationMode> shaderCompilationMode(
 Option<int> maxAnisotropy("dolphin_max_anisotropy", "Max Anisotropy", 0, 17);
 Option<bool> efbScaledCopy("dolphin_efb_scaled_copy", "Scaled EFB Copy", true);
 Option<bool> efbToTexture("dolphin_efb_to_texture", "Store EFB Copies on GPU", true);
+Option<bool> efbToVram("dolphin_efb_to_vram", "Disable EFB to VRAM", false);
 Option<bool> gpuTextureDecoding("dolphin_gpu_texture_decoding", "GPU Texture Decoding", false);
 Option<bool> waitForShaders("dolphin_wait_for_shaders", "Wait for Shaders before Starting", false);
 }  // namespace Options

--- a/Source/Core/DolphinLibretro/Options.h
+++ b/Source/Core/DolphinLibretro/Options.h
@@ -77,6 +77,7 @@ extern Option<ShaderCompilationMode> shaderCompilationMode;
 extern Option<int> maxAnisotropy;
 extern Option<bool> efbScaledCopy;
 extern Option<bool> efbToTexture;
+extern Option<bool> efbToVram;
 extern Option<bool> gpuTextureDecoding;
 extern Option<bool> waitForShaders;
 }  // namespace Options

--- a/Source/Core/DolphinLibretro/Options.h
+++ b/Source/Core/DolphinLibretro/Options.h
@@ -76,6 +76,7 @@ extern Option<unsigned int> audioMixerRate;
 extern Option<ShaderCompilationMode> shaderCompilationMode;
 extern Option<int> maxAnisotropy;
 extern Option<bool> efbScaledCopy;
+extern Option<bool> efbToTexture;
 extern Option<bool> gpuTextureDecoding;
 extern Option<bool> waitForShaders;
 }  // namespace Options


### PR DESCRIPTION
These hacks cause issues in some games such as Super Mario Bros Wii. By exposing these options, a user can either have a partial or full fix.
By disabling only the efb copy on gpu hack, there will be static blocks and no coins (partial fix). By disabling efb to vram, it's a full fix with massive performance degradation.

Similar situation in Snap and a few other games.