### PR TITLE
Use static libcurl when building the LibRetro core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -687,7 +687,7 @@ else()
 endif()
 
 find_package(CURL)
-if(CURL_FOUND)
+if(CURL_FOUND AND NOT(LIBRETRO))
   message(STATUS "Using shared libcurl")
   include_directories(${CURL_INCLUDE_DIRS})
 else()


### PR DESCRIPTION
This change in the check allows to use a static build of libcurl for
the Dolphin core and avoid issues with this library in the future.

Fixes #37.