### PR TITLE
Fix compilation issue for Apple devices

### DIFF
--- a/Externals/curl/lib/curl_setup_once.h
+++ b/Externals/curl/lib/curl_setup_once.h
@@ -119,7 +119,7 @@ struct timeval {
  * it as the fourth argument of function send()
  */
 
-#ifdef HAVE_MSG_NOSIGNAL
+#if !defined(__APPLE__) && defined(HAVE_MSG_NOSIGNAL)
 #define SEND_4TH_ARG MSG_NOSIGNAL
 #else
 #define SEND_4TH_ARG 0


### PR DESCRIPTION
The issue is caused from a wrong definition in `config.h`, which works
perfectly on every device except for OSX.

Such definition causes `curl_setup_once.h` to use `MSG_NOSIGNAL`, which
is undefined on Apple devices.
More details here:
https://github.com/lpeterse/haskell-socket/issues/8#issuecomment-115650974

The most cross-platform-friendly way (IMHO obviously) is to say to
Apple devices to ignore such definition, rewriting the preprocessor
check as done in this commit.