### PR TITLE
(libretro) Use the static png.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -613,7 +613,7 @@ else()
   set(LZO lzo2)
 endif()
 
-if(NOT APPLE AND NOT MSVC)
+if(NOT APPLE AND NOT MSVC AND NOT LIBRETRO)
   check_lib(PNG libpng png png.h QUIET)
 endif()
 if (PNG_FOUND)


### PR DESCRIPTION
Not everyone has the same version of libpng from the buildbot.