### PR TITLE
Get rid of unneeded source and dependencies

### DIFF
--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -106,6 +106,13 @@ else()
   endif()
 endif()
 
+if(MSVC)
+  target_sources(common PRIVATE
+    LdrWatcher.cpp
+    CompatPatches.cpp
+  )
+endif()
+
 # OpenGL Interface
 target_sources(common PRIVATE
   GL/GLUtil.cpp
@@ -113,39 +120,35 @@ target_sources(common PRIVATE
   GL/GLContext.cpp
 )
 
-if(ENABLE_EGL AND EGL_FOUND)
-  target_sources(common PRIVATE GL/GLInterface/EGL.cpp)
-  if(ANDROID)
-    target_sources(common PRIVATE GL/GLInterface/EGLAndroid.cpp)
-  elseif(ENABLE_X11 AND X11_FOUND)
-    target_sources(common PRIVATE GL/GLInterface/EGLX11.cpp)
-  endif()
-  target_include_directories(common PRIVATE ${EGL_INCLUDE_DIRS})
-  target_link_libraries(common PUBLIC ${EGL_LIBRARIES})
-endif()
+if(NOT LIBRETRO)
 
-if(WIN32)
-  if(NOT LIBRETRO)
+  if(ENABLE_EGL AND EGL_FOUND)
+    target_sources(common PRIVATE GL/GLInterface/EGL.cpp)
+    if(ANDROID)
+      target_sources(common PRIVATE GL/GLInterface/EGLAndroid.cpp)
+    elseif(ENABLE_X11 AND X11_FOUND)
+      target_sources(common PRIVATE GL/GLInterface/EGLX11.cpp)
+    endif()
+    target_include_directories(common PRIVATE ${EGL_INCLUDE_DIRS})
+    target_link_libraries(common PUBLIC ${EGL_LIBRARIES})
+  endif()
+
+  if(WIN32)
     target_sources(common PRIVATE
       GL/GLInterface/WGL.cpp
     )
-  endif()
-  if(MSVC)
+  elseif(APPLE)
+    target_sources(common PRIVATE GL/GLInterface/AGL.mm)
+  elseif(ENABLE_X11 AND X11_FOUND)
     target_sources(common PRIVATE
-      LdrWatcher.cpp
-      CompatPatches.cpp
-    )
-  endif()
-elseif(APPLE)
-  target_sources(common PRIVATE GL/GLInterface/AGL.mm)
-elseif(ENABLE_X11 AND X11_FOUND)
-  target_sources(common PRIVATE
-    GL/GLX11Window.cpp
-    GL/GLInterface/GLX.cpp)
+      GL/GLX11Window.cpp
+      GL/GLInterface/GLX.cpp)
 
-  # GLX has a hard dependency on libGL.
-  # Make sure to link to it if using GLX.
-  target_link_libraries(common PUBLIC ${OPENGL_LIBRARIES})
+    # GLX has a hard dependency on libGL.
+    # Make sure to link to it if using GLX.
+    target_link_libraries(common PUBLIC ${OPENGL_LIBRARIES})
+  endif()
+
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")


### PR DESCRIPTION
OS-specific Open GL context helpers are not needed