### PR TITLE
static link libgcc and libstdc++ on non-Clang/MSVC

### DIFF
--- a/Source/Core/DolphinLibretro/CMakeLists.txt
+++ b/Source/Core/DolphinLibretro/CMakeLists.txt
@@ -35,10 +35,15 @@ endif()
 
 if(NOT MSVC AND NOT CLANG)
    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
+   target_link_libraries(dolphin_libretro PRIVATE
+      core
+      uicommon
+      ${LIBS}
+      -static-libgcc -static-libstdc++)
+else()
+   target_link_libraries(dolphin_libretro PRIVATE
+      core
+      uicommon
+      ${LIBS}
+   )
 endif()
-
-target_link_libraries(dolphin_libretro PRIVATE
-  core
-  uicommon
-  ${LIBS}
-)


### PR DESCRIPTION
this makes the core loadable with the Snap package and various older distros