### PR TITLE
Allow digital-only L2/R2 triggers. Load custom textures option

### DIFF
--- a/Source/Core/DolphinLibretro/Boot.cpp
+++ b/Source/Core/DolphinLibretro/Boot.cpp
@@ -108,6 +108,7 @@ bool retro_load_game(const struct retro_game_info* game)
   Config::SetBase(Config::GFX_HACK_DISABLE_COPY_TO_VRAM, Libretro::Options::efbToVram);
   Config::SetBase(Config::GFX_ENABLE_GPU_TEXTURE_DECODING, Libretro::Options::gpuTextureDecoding);
   Config::SetBase(Config::GFX_WAIT_FOR_SHADERS_BEFORE_STARTING, Libretro::Options::waitForShaders);
+  Config::SetBase(Config::GFX_HIRES_TEXTURES, Libretro::Options::loadCustomTextures);
 #if 0
   Config::SetBase(Config::GFX_SHADER_COMPILER_THREADS, 1);
   Config::SetBase(Config::GFX_SHADER_PRECOMPILER_THREADS, 1);

--- a/Source/Core/DolphinLibretro/Input.cpp
+++ b/Source/Core/DolphinLibretro/Input.cpp
@@ -516,8 +516,8 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
     gcDPad->SetControlExpression(1, "Down");                              // Down
     gcDPad->SetControlExpression(2, "Left");                              // Left
     gcDPad->SetControlExpression(3, "Right");                             // Right
-    gcTriggers->SetControlExpression(0, "`" + devAnalog + ":Trigger0+`"); // L
-    gcTriggers->SetControlExpression(1, "`" + devAnalog + ":Trigger1+`"); // R
+    gcTriggers->SetControlExpression(0, "L2");                            // L-trigger
+    gcTriggers->SetControlExpression(1, "R2");                            // R-trigger
     gcTriggers->SetControlExpression(2, "`" + devAnalog + ":Trigger0+`"); // L-trigger Analog
     gcTriggers->SetControlExpression(3, "`" + devAnalog + ":Trigger1+`"); // R-trigger Analog
     gcRumble->SetControlExpression(0, "Rumble");
@@ -552,8 +552,8 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
       ccButtons->SetControlExpression(6, "Select");                         // -
       ccButtons->SetControlExpression(7, "Start");                          // +
       ccButtons->SetControlExpression(8, "R3");                             // Home
-      ccTriggers->SetControlExpression(0, "`" + devAnalog + ":Trigger0+`"); // L-trigger
-      ccTriggers->SetControlExpression(1, "`" + devAnalog + ":Trigger1+`"); // R-trigger
+      ccTriggers->SetControlExpression(0, "L2");                            // L-trigger
+      ccTriggers->SetControlExpression(1, "R2");                            // R-trigger
       ccTriggers->SetControlExpression(2, "`" + devAnalog + ":Trigger0+`"); // L-trigger Analog
       ccTriggers->SetControlExpression(3, "`" + devAnalog + ":Trigger1+`"); // R-trigger Analog
       ccDpad->SetControlExpression(0, "Up");                                // Up

--- a/Source/Core/DolphinLibretro/Options.cpp
+++ b/Source/Core/DolphinLibretro/Options.cpp
@@ -216,5 +216,6 @@ Option<bool> efbToTexture("dolphin_efb_to_texture", "Store EFB Copies on GPU", t
 Option<bool> efbToVram("dolphin_efb_to_vram", "Disable EFB to VRAM", false);
 Option<bool> gpuTextureDecoding("dolphin_gpu_texture_decoding", "GPU Texture Decoding", false);
 Option<bool> waitForShaders("dolphin_wait_for_shaders", "Wait for Shaders before Starting", false);
+Option<bool> loadCustomTextures("dolphin_load_custom_textures", "Load Custom Textures", false);
 }  // namespace Options
 }  // namespace Libretro

--- a/Source/Core/DolphinLibretro/Options.h
+++ b/Source/Core/DolphinLibretro/Options.h
@@ -80,5 +80,6 @@ extern Option<bool> efbToTexture;
 extern Option<bool> efbToVram;
 extern Option<bool> gpuTextureDecoding;
 extern Option<bool> waitForShaders;
+extern Option<bool> loadCustomTextures;
 }  // namespace Options
 }  // namespace Libretro

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/MixedTriggers.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/MixedTriggers.cpp
@@ -29,6 +29,20 @@ void MixedTriggers::GetState(u16* const digital, const u16* bitmasks, ControlSta
 
   for (size_t i = 0; i < trigger_count; ++i, ++bitmasks, ++analog)
   {
+#ifdef __LIBRETRO__
+    // If the analog trigger is at 0 but the digital trigger is set, we assume there's no analog trigger.
+    // Otherwise the analog trigger value takes precedence over the digital one.
+    if (controls[i + trigger_count]->control_ref->State() > numeric_settings[0]->GetValue()  // analog trigger > threshold
+        || (controls[i + trigger_count]->control_ref->State() == 0 && controls[i]->control_ref->State() > numeric_settings[0]->GetValue())) // digital trigger > threshold
+    {
+      *analog = 1.0;
+      *digital |= *bitmasks;
+    }
+    else
+    {
+      *analog = controls[i + trigger_count]->control_ref->State();
+    }
+#else
     if (controls[i]->control_ref->State() > numeric_settings[0]->GetValue())  // threshold
     {
       *analog = 1.0;
@@ -38,6 +52,7 @@ void MixedTriggers::GetState(u16* const digital, const u16* bitmasks, ControlSta
     {
       *analog = controls[i + trigger_count]->control_ref->State();
     }
+#endif
   }
 }
 }  // namespace ControllerEmu


### PR DESCRIPTION
Allow the use of digital-only triggers (keyboard and such). Issue #69 
New core option to load custom textures (same as upstream). Issue #74 
