### PR TITLE
add LIBRETRO_STATIC compile flag instead of using heuristics

### DIFF
--- a/Source/Core/DolphinLibretro/CMakeLists.txt
+++ b/Source/Core/DolphinLibretro/CMakeLists.txt
@@ -35,15 +35,19 @@ endif()
 
 if(NOT MSVC AND NOT CLANG)
    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
-   target_link_libraries(dolphin_libretro PRIVATE
-      core
-      uicommon
-      ${LIBS}
-      -static-libgcc -static-libstdc++)
 else()
    target_link_libraries(dolphin_libretro PRIVATE
       core
       uicommon
       ${LIBS}
+   )
+endif()
+   
+if(LIBRETRO_STATIC)
+   target_link_libraries(dolphin_libretro PRIVATE
+      core
+      uicommon
+      ${LIBS}
+      "-static-libgcc -static-libstdc++"
    )
 endif()


### PR DESCRIPTION
The not-clang/not-MSVC heuristic wasn't specific enough to avoid issues with some platforms (specifically, Switch), so this allows static linking to be enabled only when explicitly requested at compile time.

Goes with https://github.com/libretro/libretro-super/pull/946