### PR TITLE
Right Stick controls IR pointer

### DIFF
--- a/Source/Core/DolphinLibretro/Input.cpp
+++ b/Source/Core/DolphinLibretro/Input.cpp
@@ -626,10 +626,13 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
       wmDPad->SetControlExpression(1, "Down");                    // Down
       wmDPad->SetControlExpression(2, "Left");                    // Left
       wmDPad->SetControlExpression(3, "Right");                   // Right
-      wmIR->SetControlExpression(0, "`" + devPointer + ":Y0-`");  // Up
-      wmIR->SetControlExpression(1, "`" + devPointer + ":Y0+`");  // Down
-      wmIR->SetControlExpression(2, "`" + devPointer + ":X0-`");  // Left
-      wmIR->SetControlExpression(3, "`" + devPointer + ":X0+`");  // Right
+      
+      // Set right stick to control the IR
+      wmIR->SetControlExpression(0, "`" + devAnalog + ":Y1-`");     // Up
+      wmIR->SetControlExpression(1, "`" + devAnalog + ":Y1+`");     // Down
+      wmIR->SetControlExpression(2, "`" + devAnalog + ":X1-`");     // Left
+      wmIR->SetControlExpression(3, "`" + devAnalog + ":X1+`");     // Right
+      
       wmShake->SetControlExpression(0, "R2");                     // X
       wmShake->SetControlExpression(1, "R2");                     // Y
       wmShake->SetControlExpression(2, "R2");                     // Z

--- a/Source/Core/DolphinLibretro/Input.cpp
+++ b/Source/Core/DolphinLibretro/Input.cpp
@@ -17,6 +17,7 @@
 #include "Core/HW/WiimoteReal/WiimoteReal.h"
 #include "Core/Host.h"
 #include "DolphinLibretro/Input.h"
+#include "DolphinLibretro/Options.h"
 #include "InputCommon/ControlReference/ControlReference.h"
 #include "InputCommon/ControlReference/ExpressionParser.h"
 #include "InputCommon/ControllerEmu/Control/Control.h"
@@ -627,12 +628,20 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
       wmDPad->SetControlExpression(2, "Left");                    // Left
       wmDPad->SetControlExpression(3, "Right");                   // Right
       
-      // Set right stick to control the IR
-      wmIR->SetControlExpression(0, "`" + devAnalog + ":Y1-`");     // Up
-      wmIR->SetControlExpression(1, "`" + devAnalog + ":Y1+`");     // Down
-      wmIR->SetControlExpression(2, "`" + devAnalog + ":X1-`");     // Left
-      wmIR->SetControlExpression(3, "`" + devAnalog + ":X1+`");     // Right
-      
+      if(Libretro::Options::irMode==1){
+        // Set right stick to control the IR
+        wmIR->SetControlExpression(0, "`" + devAnalog + ":Y1-`");     // Up
+        wmIR->SetControlExpression(1, "`" + devAnalog + ":Y1+`");     // Down
+        wmIR->SetControlExpression(2, "`" + devAnalog + ":X1-`");     // Left
+        wmIR->SetControlExpression(3, "`" + devAnalog + ":X1+`");     // Right
+      }
+      else {
+        // Mouse controls IR
+        wmIR->SetControlExpression(0, "`" + devPointer + ":Y0-`");  // Up
+        wmIR->SetControlExpression(1, "`" + devPointer + ":Y0+`");  // Down
+        wmIR->SetControlExpression(2, "`" + devPointer + ":X0-`");  // Left        
+        wmIR->SetControlExpression(3, "`" + devPointer + ":X0+`");  // Right
+      }
       wmShake->SetControlExpression(0, "R2");                     // X
       wmShake->SetControlExpression(1, "R2");                     // Y
       wmShake->SetControlExpression(2, "R2");                     // Z

--- a/Source/Core/DolphinLibretro/Options.cpp
+++ b/Source/Core/DolphinLibretro/Options.cpp
@@ -149,7 +149,8 @@ Option<int> efbScale("dolphin_efb_scale", "EFB Scale", 1,
                      {"x1 (640 x 528)", "x2 (1280 x 1056)", "x3 (1920 x 1584)", "x4 (2560 * 2112)",
                       "x5 (3200 x 2640)", "x6 (3840 x 3168)"});
 Option<int> irMode("dolphin_ir_mode", "IR Mode", 1,
-                     {"Right Stick controls pointer", "Mouse controls pointer"});Option<LogTypes::LOG_LEVELS> logLevel("dolphin_log_level", "Log Level",
+                     {"Right Stick controls pointer", "Mouse controls pointer"});
+Option<LogTypes::LOG_LEVELS> logLevel("dolphin_log_level", "Log Level",
                                       {{"Info", LogTypes::LINFO},
 #if defined(_DEBUG) || defined(DEBUGFAST)
                                        {"Debug", LogTypes::LDEBUG},

--- a/Source/Core/DolphinLibretro/Options.cpp
+++ b/Source/Core/DolphinLibretro/Options.cpp
@@ -148,7 +148,8 @@ bool Option<T>::Updated()
 Option<int> efbScale("dolphin_efb_scale", "EFB Scale", 1,
                      {"x1 (640 x 528)", "x2 (1280 x 1056)", "x3 (1920 x 1584)", "x4 (2560 * 2112)",
                       "x5 (3200 x 2640)", "x6 (3840 x 3168)"});
-Option<LogTypes::LOG_LEVELS> logLevel("dolphin_log_level", "Log Level",
+Option<int> irMode("dolphin_ir_mode", "IR Mode", 1,
+                     {"Right Stick controls pointer", "Mouse controls pointer"});Option<LogTypes::LOG_LEVELS> logLevel("dolphin_log_level", "Log Level",
                                       {{"Info", LogTypes::LINFO},
 #if defined(_DEBUG) || defined(DEBUGFAST)
                                        {"Debug", LogTypes::LDEBUG},

--- a/Source/Core/DolphinLibretro/Options.h
+++ b/Source/Core/DolphinLibretro/Options.h
@@ -58,6 +58,7 @@ private:
   std::vector<std::pair<std::string, T>> m_list;
 };
 
+extern Option<int> irMode;
 extern Option<int> efbScale;
 extern Option<LogTypes::LOG_LEVELS> logLevel;
 extern Option<float> cpuClockRate;

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.cpp
@@ -47,8 +47,8 @@ Cursor::Cursor(const std::string& name_) : ControlGroup(name_, GroupType::Cursor
     numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Width"), 0.5));
     numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Height"), 0.5));
     numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Dead Zone"), 0, 0, 20));
-    boolean_settings.emplace_back(std::make_unique<BooleanSetting>(_trans("Relative Input"), true));
-    boolean_settings.emplace_back(std::make_unique<BooleanSetting>(_trans("Auto-Hide"), true));
+    boolean_settings.emplace_back(std::make_unique<BooleanSetting>(_trans("Relative Input"), false));
+    boolean_settings.emplace_back(std::make_unique<BooleanSetting>(_trans("Auto-Hide"), false));
   }
 
 }

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.cpp
@@ -32,11 +32,11 @@ Cursor::Cursor(const std::string& name_) : ControlGroup(name_, GroupType::Cursor
   controls.emplace_back(std::make_unique<Input>(Translate, _trans("Recenter")));
 
   numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Center"), 0.5));
-  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Width"), 0.5));
-  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Height"), 0.5));
-  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Dead Zone"), 0, 0, 20));
-  boolean_settings.emplace_back(std::make_unique<BooleanSetting>(_trans("Relative Input"), false));
-  boolean_settings.emplace_back(std::make_unique<BooleanSetting>(_trans("Auto-Hide"), false));
+  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Width"), 0.1));
+  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Height"), 0.2));
+  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Dead Zone"), 0, 0, 4));
+  boolean_settings.emplace_back(std::make_unique<BooleanSetting>(_trans("Relative Input"), true));
+  boolean_settings.emplace_back(std::make_unique<BooleanSetting>(_trans("Auto-Hide"), true));
 }
 
 Cursor::StateData Cursor::GetState(const bool adjusted)

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.cpp
@@ -19,6 +19,8 @@
 #include "InputCommon/ControllerEmu/Setting/BooleanSetting.h"
 #include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 
+#include "DolphinLibretro/Options.h"
+
 namespace ControllerEmu
 {
 Cursor::Cursor(const std::string& name_) : ControlGroup(name_, GroupType::Cursor)
@@ -30,13 +32,25 @@ Cursor::Cursor(const std::string& name_) : ControlGroup(name_, GroupType::Cursor
   controls.emplace_back(std::make_unique<Input>(Translate, _trans("Backward")));
   controls.emplace_back(std::make_unique<Input>(Translate, _trans("Hide")));
   controls.emplace_back(std::make_unique<Input>(Translate, _trans("Recenter")));
+  if(Libretro::Options::irMode==1){
+    // Set right stick to control the IR
+    numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Center"), 0.5));
+    numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Width"), 0.1));
+    numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Height"), 0.2));
+    numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Dead Zone"), 0, 0, 4));
+    boolean_settings.emplace_back(std::make_unique<BooleanSetting>(_trans("Relative Input"), true));
+    boolean_settings.emplace_back(std::make_unique<BooleanSetting>(_trans("Auto-Hide"), true));
+  }
+  else {
+    // Mouse controls IR
+    numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Center"), 0.5));
+    numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Width"), 0.5));
+    numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Height"), 0.5));
+    numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Dead Zone"), 0, 0, 20));
+    boolean_settings.emplace_back(std::make_unique<BooleanSetting>(_trans("Relative Input"), true));
+    boolean_settings.emplace_back(std::make_unique<BooleanSetting>(_trans("Auto-Hide"), true));
+  }
 
-  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Center"), 0.5));
-  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Width"), 0.1));
-  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Height"), 0.2));
-  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Dead Zone"), 0, 0, 4));
-  boolean_settings.emplace_back(std::make_unique<BooleanSetting>(_trans("Relative Input"), true));
-  boolean_settings.emplace_back(std::make_unique<BooleanSetting>(_trans("Auto-Hide"), true));
 }
 
 Cursor::StateData Cursor::GetState(const bool adjusted)


### PR DESCRIPTION
This allows the Wii/IR pointer to be controlled by the right analog stick.  Fixes #79