### PR TITLE
libretro doesn't use native inputs

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
@@ -14,6 +14,7 @@
 #include "InputCommon/ControllerInterface/Device.h"
 
 // enable disable sources
+#ifndef __LIBRETRO__
 #ifdef _WIN32
 #define CIFACE_USE_XINPUT
 #define CIFACE_USE_DINPUT
@@ -29,6 +30,7 @@
 #endif
 #if defined(USE_PIPES)
 #define CIFACE_USE_PIPES
+#endif
 #endif
 
 //


### PR DESCRIPTION
Fix exit crash on OSX