### PR TITLE
New core options for IR center/width/height

### DIFF
--- a/Source/Core/DolphinLibretro/Input.cpp
+++ b/Source/Core/DolphinLibretro/Input.cpp
@@ -447,6 +447,12 @@ void Update()
 #endif
 }
 
+void ResetControllers()
+{
+  for (int port = 0; port < 4; port++)
+    retro_set_controller_port_device(port, input_types[port]);
+}
+
 }  // namespace Input
 }  // namespace Libretro
 
@@ -583,6 +589,9 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
 
       wmButtons->SetControlExpression(0, "A | `" + devPointer + ":Pressed0`");  // A
       wmButtons->SetControlExpression(1, "B");                                  // B
+      wmIR->numeric_settings[0]->SetValue(Libretro::Options::irCenter / 100.0); // IR Center
+      wmIR->numeric_settings[1]->SetValue(Libretro::Options::irWidth / 100.0);  // IR Width
+      wmIR->numeric_settings[2]->SetValue(Libretro::Options::irHeight / 100.0); // IR Height
 
       if (device == RETRO_DEVICE_WIIMOTE_NC)
       {
@@ -627,19 +636,25 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
       wmDPad->SetControlExpression(2, "Left");                    // Left
       wmDPad->SetControlExpression(3, "Right");                   // Right
       
-      if(Libretro::Options::irMode==1){
+      if (Libretro::Options::irMode == 1)
+      {
         // Set right stick to control the IR
         wmIR->SetControlExpression(0, "`" + devAnalog + ":Y1-`");     // Up
         wmIR->SetControlExpression(1, "`" + devAnalog + ":Y1+`");     // Down
         wmIR->SetControlExpression(2, "`" + devAnalog + ":X1-`");     // Left
         wmIR->SetControlExpression(3, "`" + devAnalog + ":X1+`");     // Right
+        wmIR->boolean_settings[0]->SetValue(false);                   // Relative input
+        wmIR->boolean_settings[1]->SetValue(true);                    // Auto hide
       }
-      else {
+      else
+      {
         // Mouse controls IR
         wmIR->SetControlExpression(0, "`" + devPointer + ":Y0-`");  // Up
         wmIR->SetControlExpression(1, "`" + devPointer + ":Y0+`");  // Down
         wmIR->SetControlExpression(2, "`" + devPointer + ":X0-`");  // Left        
         wmIR->SetControlExpression(3, "`" + devPointer + ":X0+`");  // Right
+        wmIR->boolean_settings[0]->SetValue(false);                 // Relative input
+        wmIR->boolean_settings[1]->SetValue(false);                 // Auto hide
       }
       wmShake->SetControlExpression(0, "R2");                     // X
       wmShake->SetControlExpression(1, "R2");                     // Y

--- a/Source/Core/DolphinLibretro/Input.h
+++ b/Source/Core/DolphinLibretro/Input.h
@@ -8,5 +8,6 @@ namespace Input
 void Init();
 void Update();
 void Shutdown();
+void ResetControllers();
 }
 }

--- a/Source/Core/DolphinLibretro/Main.cpp
+++ b/Source/Core/DolphinLibretro/Main.cpp
@@ -232,6 +232,12 @@ void retro_run(void)
     Libretro::environ_cb(RETRO_ENVIRONMENT_SET_GEOMETRY, &info);
   }
 
+  if (Libretro::Options::irMode.Updated() || Libretro::Options::irCenter.Updated()
+      || Libretro::Options::irWidth.Updated() || Libretro::Options::irHeight.Updated())
+  {
+    Libretro::Input::ResetControllers();
+  }
+
   if (Libretro::Options::bluetoothContinuousScan.Updated()
       && Libretro::Options::bluetoothContinuousScan != SConfig::GetInstance().m_WiimoteContinuousScanning)
   {

--- a/Source/Core/DolphinLibretro/Options.cpp
+++ b/Source/Core/DolphinLibretro/Options.cpp
@@ -148,8 +148,14 @@ bool Option<T>::Updated()
 Option<int> efbScale("dolphin_efb_scale", "EFB Scale", 1,
                      {"x1 (640 x 528)", "x2 (1280 x 1056)", "x3 (1920 x 1584)", "x4 (2560 * 2112)",
                       "x5 (3200 x 2640)", "x6 (3840 x 3168)"});
-Option<int> irMode("dolphin_ir_mode", "IR Mode", 1,
+Option<int> irMode("dolphin_ir_mode", "Wiimote IR Mode", 1,
                      {"Right Stick controls pointer", "Mouse controls pointer"});
+Option<int> irCenter("dolphin_ir_center", "Wiimote IR Center",
+  { {"50", 50}, {"60", 60}, {"70", 70}, {"80", 80}, {"90", 90}, {"100", 100}, {"0", 0}, {"10", 10}, {"20", 20}, {"30", 30}, {"40", 40} });
+Option<int> irWidth("dolphin_ir_width", "Wiimote IR Width",
+  { {"50", 50}, {"60", 60}, {"70", 70}, {"80", 80}, {"90", 90}, {"100", 100}, {"0", 0}, {"10", 10}, {"20", 20}, {"30", 30}, {"40", 40} });
+Option<int> irHeight("dolphin_ir_height", "Wiimote IR Height",
+  { {"50", 50}, {"60", 60}, {"70", 70}, {"80", 80}, {"90", 90}, {"100", 100}, {"0", 0}, {"10", 10}, {"20", 20}, {"30", 30}, {"40", 40} });
 Option<LogTypes::LOG_LEVELS> logLevel("dolphin_log_level", "Log Level",
                                       {{"Info", LogTypes::LINFO},
 #if defined(_DEBUG) || defined(DEBUGFAST)

--- a/Source/Core/DolphinLibretro/Options.h
+++ b/Source/Core/DolphinLibretro/Options.h
@@ -59,6 +59,9 @@ private:
 };
 
 extern Option<int> irMode;
+extern Option<int> irCenter;
+extern Option<int> irWidth;
+extern Option<int> irHeight;
 extern Option<int> efbScale;
 extern Option<LogTypes::LOG_LEVELS> logLevel;
 extern Option<float> cpuClockRate;

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.cpp
@@ -19,8 +19,6 @@
 #include "InputCommon/ControllerEmu/Setting/BooleanSetting.h"
 #include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 
-#include "DolphinLibretro/Options.h"
-
 namespace ControllerEmu
 {
 Cursor::Cursor(const std::string& name_) : ControlGroup(name_, GroupType::Cursor)
@@ -32,25 +30,13 @@ Cursor::Cursor(const std::string& name_) : ControlGroup(name_, GroupType::Cursor
   controls.emplace_back(std::make_unique<Input>(Translate, _trans("Backward")));
   controls.emplace_back(std::make_unique<Input>(Translate, _trans("Hide")));
   controls.emplace_back(std::make_unique<Input>(Translate, _trans("Recenter")));
-  if(Libretro::Options::irMode==1){
-    // Set right stick to control the IR
-    numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Center"), 0.5));
-    numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Width"), 0.1));
-    numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Height"), 0.2));
-    numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Dead Zone"), 0, 0, 4));
-    boolean_settings.emplace_back(std::make_unique<BooleanSetting>(_trans("Relative Input"), true));
-    boolean_settings.emplace_back(std::make_unique<BooleanSetting>(_trans("Auto-Hide"), true));
-  }
-  else {
-    // Mouse controls IR
-    numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Center"), 0.5));
-    numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Width"), 0.5));
-    numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Height"), 0.5));
-    numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Dead Zone"), 0, 0, 20));
-    boolean_settings.emplace_back(std::make_unique<BooleanSetting>(_trans("Relative Input"), false));
-    boolean_settings.emplace_back(std::make_unique<BooleanSetting>(_trans("Auto-Hide"), false));
-  }
 
+  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Center"), 0.5));
+  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Width"), 0.5));
+  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Height"), 0.5));
+  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Dead Zone"), 0, 0, 20));
+  boolean_settings.emplace_back(std::make_unique<BooleanSetting>(_trans("Relative Input"), false));
+  boolean_settings.emplace_back(std::make_unique<BooleanSetting>(_trans("Auto-Hide"), false));
 }
 
 Cursor::StateData Cursor::GetState(const bool adjusted)


### PR DESCRIPTION
Move IR mode changes out of common code into Libretro namespace
Reset controllers when IR mode, center, width or height is changed
Disable Relative input when controlling IR with right stick

Issue #85 