### PR TITLE
enable bbox emu and cheats as core options

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -46,6 +46,8 @@
 
 #include "DiscIO/Enums.h"
 
+#include "DolphinLibretro/Options.h"
+
 #include "VideoCommon/VideoBackendBase.h"
 
 namespace BootManager
@@ -249,7 +251,7 @@ bool BootCore(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi)
 
     core_section->Get("CPUThread", &StartUp.bCPUThread, StartUp.bCPUThread);
     core_section->Get("JITFollowBranch", &StartUp.bJITFollowBranch, StartUp.bJITFollowBranch);
-    core_section->Get("EnableCheats", &StartUp.bEnableCheats, StartUp.bEnableCheats);
+    StartUp.bEnableCheats = Libretro::Options::cheatsEnabled;
     core_section->Get("SyncOnSkipIdle", &StartUp.bSyncGPUOnSkipIdleHack,
                       StartUp.bSyncGPUOnSkipIdleHack);
     core_section->Get("FPRF", &StartUp.bFPRF, StartUp.bFPRF);

--- a/Source/Core/DolphinLibretro/Boot.cpp
+++ b/Source/Core/DolphinLibretro/Boot.cpp
@@ -106,6 +106,7 @@ bool retro_load_game(const struct retro_game_info* game)
   Config::SetBase(Config::GFX_HACK_COPY_EFB_SCALED, Libretro::Options::efbScaledCopy);
   Config::SetBase(Config::GFX_HACK_SKIP_EFB_COPY_TO_RAM, Libretro::Options::efbToTexture);
   Config::SetBase(Config::GFX_HACK_DISABLE_COPY_TO_VRAM, Libretro::Options::efbToVram);
+  Config::SetBase(Config::GFX_HACK_BBOX_ENABLE, Libretro::Options::bboxEnabled);
   Config::SetBase(Config::GFX_ENABLE_GPU_TEXTURE_DECODING, Libretro::Options::gpuTextureDecoding);
   Config::SetBase(Config::GFX_WAIT_FOR_SHADERS_BEFORE_STARTING, Libretro::Options::waitForShaders);
   Config::SetBase(Config::GFX_ENHANCE_FORCE_FILTERING, Libretro::Options::forceTextureFiltering);

--- a/Source/Core/DolphinLibretro/Options.cpp
+++ b/Source/Core/DolphinLibretro/Options.cpp
@@ -228,5 +228,6 @@ Option<bool> gpuTextureDecoding("dolphin_gpu_texture_decoding", "GPU Texture Dec
 Option<bool> waitForShaders("dolphin_wait_for_shaders", "Wait for Shaders before Starting", false);
 Option<bool> forceTextureFiltering("dolphin_force_texture_filtering", "Force Texture Filtering", false);
 Option<bool> loadCustomTextures("dolphin_load_custom_textures", "Load Custom Textures", false);
+Option<bool> cheatsEnabled("dolphin_cheats_enabled", "Internal Cheats Enabled", false);
 }  // namespace Options
 }  // namespace Libretro

--- a/Source/Core/DolphinLibretro/Options.cpp
+++ b/Source/Core/DolphinLibretro/Options.cpp
@@ -223,6 +223,7 @@ Option<int> maxAnisotropy("dolphin_max_anisotropy", "Max Anisotropy", 0, 17);
 Option<bool> efbScaledCopy("dolphin_efb_scaled_copy", "Scaled EFB Copy", true);
 Option<bool> efbToTexture("dolphin_efb_to_texture", "Store EFB Copies on GPU", true);
 Option<bool> efbToVram("dolphin_efb_to_vram", "Disable EFB to VRAM", false);
+Option<bool> bboxEnabled("dolphin_bbox_enabled", "Bounding Box Emulation", false);
 Option<bool> gpuTextureDecoding("dolphin_gpu_texture_decoding", "GPU Texture Decoding", false);
 Option<bool> waitForShaders("dolphin_wait_for_shaders", "Wait for Shaders before Starting", false);
 Option<bool> forceTextureFiltering("dolphin_force_texture_filtering", "Force Texture Filtering", false);

--- a/Source/Core/DolphinLibretro/Options.h
+++ b/Source/Core/DolphinLibretro/Options.h
@@ -88,5 +88,6 @@ extern Option<bool> waitForShaders;
 extern Option<bool> forceTextureFiltering;
 extern Option<bool> loadCustomTextures;
 extern Option<bool> bluetoothContinuousScan;
+extern Option<bool> cheatsEnabled;
 }  // namespace Options
 }  // namespace Libretro

--- a/Source/Core/DolphinLibretro/Options.h
+++ b/Source/Core/DolphinLibretro/Options.h
@@ -82,6 +82,7 @@ extern Option<int> maxAnisotropy;
 extern Option<bool> efbScaledCopy;
 extern Option<bool> efbToTexture;
 extern Option<bool> efbToVram;
+extern Option<bool> bboxEnabled;
 extern Option<bool> gpuTextureDecoding;
 extern Option<bool> waitForShaders;
 extern Option<bool> forceTextureFiltering;


### PR DESCRIPTION
Tested and works on Switch-Lakka. I don't see any reason why it wouldn't work elsewhere. I followed the same GFX.ini -> core option method that was used for `efbToTexture`. Cheat support was a little different but same general idea.