### PR TITLE
adding texture cache accuracy to core options

### DIFF
--- a/Source/Core/DolphinLibretro/Boot.cpp
+++ b/Source/Core/DolphinLibretro/Boot.cpp
@@ -111,6 +111,7 @@ bool retro_load_game(const struct retro_game_info* game)
   Config::SetBase(Config::GFX_WAIT_FOR_SHADERS_BEFORE_STARTING, Libretro::Options::waitForShaders);
   Config::SetBase(Config::GFX_ENHANCE_FORCE_FILTERING, Libretro::Options::forceTextureFiltering);
   Config::SetBase(Config::GFX_HIRES_TEXTURES, Libretro::Options::loadCustomTextures);
+  Config::SetBase(Config::GFX_SAFE_TEXTURE_CACHE_COLOR_SAMPLES, Libretro::Options::textureCacheAccuracy);
 #if 0
   Config::SetBase(Config::GFX_SHADER_COMPILER_THREADS, 1);
   Config::SetBase(Config::GFX_SHADER_PRECOMPILER_THREADS, 1);

--- a/Source/Core/DolphinLibretro/Options.cpp
+++ b/Source/Core/DolphinLibretro/Options.cpp
@@ -229,5 +229,7 @@ Option<bool> waitForShaders("dolphin_wait_for_shaders", "Wait for Shaders before
 Option<bool> forceTextureFiltering("dolphin_force_texture_filtering", "Force Texture Filtering", false);
 Option<bool> loadCustomTextures("dolphin_load_custom_textures", "Load Custom Textures", false);
 Option<bool> cheatsEnabled("dolphin_cheats_enabled", "Internal Cheats Enabled", false);
+Option<int> textureCacheAccuracy("dolphin_texture_cache_accuracy", "Texture Cache Accuracy",
+                                 {{"Fast", 128}, {"Middle", 512}, {"Safe", 0}});
 }  // namespace Options
 }  // namespace Libretro

--- a/Source/Core/DolphinLibretro/Options.h
+++ b/Source/Core/DolphinLibretro/Options.h
@@ -89,5 +89,6 @@ extern Option<bool> forceTextureFiltering;
 extern Option<bool> loadCustomTextures;
 extern Option<bool> bluetoothContinuousScan;
 extern Option<bool> cheatsEnabled;
+extern Option<int> textureCacheAccuracy;
 }  // namespace Options
 }  // namespace Libretro


### PR DESCRIPTION
built and tested with Pokemon XD, which had issues at fast cache accuracy. made the same edits as the changes I made to add bbox emu to core options.