### PR TITLE
Fix gcc10 std::string error

### DIFF
--- a/Source/Core/DiscIO/DiscExtractor.h
+++ b/Source/Core/DiscIO/DiscExtractor.h
@@ -6,6 +6,7 @@
 
 #include <functional>
 #include <optional>
+#include <string>
 
 #include "Common/CommonTypes.h"
 


### PR DESCRIPTION
When building with gcc10, it has error:

```
[  188s] /home/abuild/rpmbuild/BUILD/libretro-dolphin-0~git20200525/Source/Core/DiscIO/DiscExtractor.h:18:6: error: 'string' in namespace 'std' does not name a type
[  188s]    18 | std::string DirectoryNameForPartitionType(u32 partition_type);
[  188s]       |      ^~~~~~
[  188s] /home/abuild/rpmbuild/BUILD/libretro-dolphin-0~git20200525/Source/Core/DiscIO/DiscExtractor.h:11:1: note: 'std::string' is defined in header '<string>'; did you forget to '#include <string>'?
[  188s]    10 | #include "Common/CommonTypes.h"
[  188s]   +++ |+#include <string>
```