### PR TITLE
default fastmem core option OFF for Android

### DIFF
--- a/Source/Core/DolphinLibretro/Options.cpp
+++ b/Source/Core/DolphinLibretro/Options.cpp
@@ -181,7 +181,11 @@ Option<float> cpuClockRate("dolphin_cpu_clock_rate", "CPU Clock Rate",
                             {"80%", 0.8},
                             {"90%", 0.9}});
 Option<std::string> renderer("dolphin_renderer", "Renderer", {"Hardware", "Software", "Null"});
+#ifdef ANDROID
+Option<bool> fastmem("dolphin_fastmem", "Fastmem", false);
+#else
 Option<bool> fastmem("dolphin_fastmem", "Fastmem", true);
+#endif
 Option<bool> DSPHLE("dolphin_dsp_hle", "DSP HLE", true);
 Option<bool> DSPEnableJIT("dolphin_dsp_jit", "DSP Enable JIT", true);
 Option<PowerPC::CPUCore> cpu_core("dolphin_cpu_core", "CPU Core",


### PR DESCRIPTION
This option causes Gamecube games to instantly crash on Android. Disabling it makes them slow, but at least it actually launches.