### PR TITLE
Input fixes/improvements

### DIFF
--- a/Source/Core/DolphinLibretro/Input.cpp
+++ b/Source/Core/DolphinLibretro/Input.cpp
@@ -59,6 +59,8 @@ static struct retro_input_descriptor descGC[] = {
     {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L, "L"},
     {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R, "R"},
     {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2, "Z"},
+    {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3, "L-Analog"},
+    {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3, "R-Analog"},
     {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START, "Start"},
     {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, "Select"},
     {0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X,
@@ -516,8 +518,8 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
     gcDPad->SetControlExpression(3, "Right");                             // Right
     gcTriggers->SetControlExpression(0, "L");                             // L
     gcTriggers->SetControlExpression(1, "R");                             // R
-    gcTriggers->SetControlExpression(2, "`" + devAnalog + "Trigger0+`");  // L-trigger Analog
-    gcTriggers->SetControlExpression(3, "`" + devAnalog + "Trigger1+`");  // R-trigger Analog
+    gcTriggers->SetControlExpression(2, "L3");  // L-trigger Analog
+    gcTriggers->SetControlExpression(3, "R3");  // R-trigger Analog
     gcRumble->SetControlExpression(0, "Rumble");
 
     gcPad->UpdateReferences(g_controller_interface);

--- a/Source/Core/DolphinLibretro/Input.cpp
+++ b/Source/Core/DolphinLibretro/Input.cpp
@@ -494,13 +494,12 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
   std::string devMouse = Libretro::Input::GetQualifiedName(port, RETRO_DEVICE_MOUSE);
   std::string devPointer = Libretro::Input::GetQualifiedName(port, RETRO_DEVICE_POINTER);
 #if 0
-  std::string devMouse = Libretro::Input::GetQualifiedName(port, RETRO_DEVICE_MOUSE);
   std::string devKeyboard = Libretro::Input::GetQualifiedName(port, RETRO_DEVICE_KEYBOARD);
   std::string devLightgun = Libretro::Input::GetQualifiedName(port, RETRO_DEVICE_LIGHTGUN);
 #endif
 
   Libretro::Input::RemoveDevicesForPort(port);
-  if (device != RETRO_DEVICE_NONE)
+  if (device != RETRO_DEVICE_NONE && device != RETRO_DEVICE_REAL_WIIMOTE)
     Libretro::Input::AddDevicesForPort(port);
 
   if (!SConfig::GetInstance().bWii || port > 3)
@@ -607,8 +606,6 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
       ControllerEmu::ControlGroup* wmHotkeys = wm->GetWiimoteGroup(WiimoteGroup::Hotkeys);
 #endif
 
-      wmButtons->SetControlExpression(0, "A | `" + devMouse + ":Left`");   // A
-      wmButtons->SetControlExpression(1, "B | `" + devMouse + ":Right`");  // B
 
       if (device == RETRO_DEVICE_WIIMOTE_NC)
       {
@@ -630,6 +627,8 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
         ncShake->SetControlExpression(1, "L2");                       // Y
         ncShake->SetControlExpression(2, "L2");                       // Z
 
+        wmButtons->SetControlExpression(0, "A | `" + devMouse + ":Left`");   // A
+        wmButtons->SetControlExpression(1, "B | `" + devMouse + ":Right`");  // B
         wmButtons->SetControlExpression(2, "Start");                         // 1
         wmButtons->SetControlExpression(3, "Select");                        // 2
         wmButtons->SetControlExpression(4, "L");                             // -
@@ -785,7 +784,7 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
       }
       break;
     }
-    for (int j = 0; desc[j].device != 0; j++)
+    for (int j = 0; desc[j].description != NULL; j++)
     {
       retro_input_descriptor new_desc = desc[j];
       new_desc.port = i;


### PR DESCRIPTION
- Add L3/R3 as aliases for soft shoulder presses for GC Controllers.
- Allow more range when analog triggers are used for GC Controllers.
- Enable GC Controller input in ports 5-8 in Wii mode.
- Fix sideways Wiimote input expressions so the input descriptors are correct.