### PR TITLE
Update Valid File Extensions

### DIFF
--- a/Source/Core/DolphinLibretro/Main.cpp
+++ b/Source/Core/DolphinLibretro/Main.cpp
@@ -137,7 +137,7 @@ void retro_deinit(void)
 void retro_get_system_info(retro_system_info* info)
 {
   info->need_fullpath = true;
-  info->valid_extensions = "elf|dol|gcm|iso|tgc|wbfs|ciso|gcz|wad";
+  info->valid_extensions = "elf|dol|gcm|iso|tgc|wbfs|ciso|gcz|wad|wia|rvz";
   info->library_version = Common::scm_desc_str.c_str();
   info->library_name = "dolphin-emu";
   info->block_extract = true;


### PR DESCRIPTION
Adds WIA and RVZ (compressed disc image) file extensions for Libretro