### PR TITLE
M3U and Disc Control interface fixes

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -162,6 +162,8 @@ BootParameters::GenerateFromFile(std::vector<std::string> paths,
     std::transform(extension.begin(), extension.end(), extension.begin(), ::tolower);
   }
 
+  Libretro::AddDiscs(paths);
+
   std::string path = paths.front();
   if (paths.size() == 1)
     paths.clear();

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -139,6 +139,14 @@ BootParameters::GenerateFromFile(std::vector<std::string> paths,
     return {};
   }
 
+  // Dolphin expects to be able to use "/" (DIR_SEP) everywhere.
+  // RetroArch uses the OS separator.
+  constexpr fs::path::value_type os_separator = fs::path::preferred_separator;
+  static_assert(os_separator == DIR_SEP_CHR || os_separator == '\\', "Unsupported path separator");
+  if (os_separator != DIR_SEP_CHR)
+    for (auto& path : paths)
+      std::replace(path.begin(), path.end(), '\\', DIR_SEP_CHR);
+
   std::string folder_path;
   std::string extension;
   SplitPath(paths.front(), &folder_path, nullptr, &extension);

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -7,7 +7,6 @@
 #ifdef _MSC_VER
 #include <filesystem>
 namespace fs = std::filesystem;
-#define HAS_STD_FILESYSTEM
 #endif
 
 #include <algorithm>
@@ -139,6 +138,7 @@ BootParameters::GenerateFromFile(std::vector<std::string> paths,
     return {};
   }
 
+#ifdef _MSC_VER
   // Dolphin expects to be able to use "/" (DIR_SEP) everywhere.
   // RetroArch uses the OS separator.
   constexpr fs::path::value_type os_separator = fs::path::preferred_separator;
@@ -146,6 +146,7 @@ BootParameters::GenerateFromFile(std::vector<std::string> paths,
   if (os_separator != DIR_SEP_CHR)
     for (auto& path : paths)
       std::replace(path.begin(), path.end(), '\\', DIR_SEP_CHR);
+#endif
 
   std::string folder_path;
   std::string extension;

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -4,6 +4,12 @@
 
 #include "Core/Boot/Boot.h"
 
+#ifdef _MSC_VER
+#include <filesystem>
+namespace fs = std::filesystem;
+#define HAS_STD_FILESYSTEM
+#endif
+
 #include <algorithm>
 #include <array>
 #include <cstring>

--- a/Source/Core/Core/Boot/Boot.h
+++ b/Source/Core/Core/Boot/Boot.h
@@ -162,3 +162,8 @@ void UpdateStateFlags(std::function<void(StateFlags*)> update_function);
 /// Normally, this is automatically done by ES when the System Menu is installed,
 /// but we cannot rely on this because we don't require any system titles to be installed.
 void CreateSystemMenuTitleDirs();
+
+namespace Libretro
+{
+void AddDiscs(std::vector<std::string> paths);
+}

--- a/Source/Core/Core/Boot/Boot.h
+++ b/Source/Core/Core/Boot/Boot.h
@@ -163,7 +163,6 @@ void UpdateStateFlags(std::function<void(StateFlags*)> update_function);
 /// but we cannot rely on this because we don't require any system titles to be installed.
 void CreateSystemMenuTitleDirs();
 
-namespace Libretro
-{
-void AddDiscs(std::vector<std::string> paths);
-}
+#ifdef __LIBRETRO__
+std::vector<std::string> ReadM3UFile(const std::string& m3u_path, const std::string& folder_path);
+#endif

--- a/Source/Core/DolphinLibretro/Main.cpp
+++ b/Source/Core/DolphinLibretro/Main.cpp
@@ -137,7 +137,7 @@ void retro_deinit(void)
 void retro_get_system_info(retro_system_info* info)
 {
   info->need_fullpath = true;
-  info->valid_extensions = "elf|dol|gcm|iso|tgc|wbfs|ciso|gcz|wad|wia|rvz";
+  info->valid_extensions = "elf|dol|gcm|iso|tgc|wbfs|ciso|gcz|wad|wia|rvz|m3u";
   info->library_version = Common::scm_desc_str.c_str();
   info->library_name = "dolphin-emu";
   info->block_extract = true;


### PR DESCRIPTION
It seems like there were mixed reports in the current/previous issues and PRs on whether or not m3u support and the disc control interface were working or not. I fixed the issues I ran into one by one and these things seem to be fixed now. Some of this may not be ideal as I'm not hugely familiar with the Dolphin code, and am also still wrapping my head around libretro's disc control interface, but the results are there.

### M3u support
Fixed by added m3u to list of supported extensions, and then normalizing slash in path to m3u before feeding it to Dolphin's path split function (which expects to only see forward slashes). Previously, m3u could not be loaded, and when they were, would have incorrect absolute paths calculated for the contents in most cases on Windows.

### Disc Control
There was a previous PR for disc control, but I'm not exactly sure what it did functionally. The callbacks had basic implementations, but until the additional changes, none of the discs from the m3u were populating into the selectable indexes.

### Other
Fixes #97
Also relates to #182, but I didn't test that specific case. Instead of manually adding discs, however, switching to others in the m3u does seem to work.
Edit: Fixes #182. See below