### PR TITLE
"Max Anisotropy" core option fix

### DIFF
--- a/Source/Core/DolphinLibretro/Options.cpp
+++ b/Source/Core/DolphinLibretro/Options.cpp
@@ -180,7 +180,7 @@ Option<ShaderCompilationMode> shaderCompilationMode(
      {"a-sync Skip Rendering", ShaderCompilationMode::AsynchronousSkipRendering},
      {"sync UberShaders", ShaderCompilationMode::SynchronousUberShaders},
      {"a-sync UberShaders", ShaderCompilationMode::AsynchronousUberShaders}});
-Option<int> maxAnisotropy("dolphin_max_anisotropy", "Max Anisotropy", 0, 17);
+Option<int> maxAnisotropy("dolphin_max_anisotropy", "Max Anisotropy", {"1x", "2x", "4x", "8x", "16x"});
 Option<bool> efbScaledCopy("dolphin_efb_scaled_copy", "Scaled EFB Copy", true);
 Option<bool> efbToTexture("dolphin_efb_to_texture", "Store EFB Copies on GPU", true);
 Option<bool> efbToVram("dolphin_efb_to_vram", "Disable EFB to VRAM", false);


### PR DESCRIPTION
Currently the "Max Anisotropy" core option goes from "0" to "16" and write these values in `retroarch/saves/User/Config/GFX.ini`, which creates graphical issues (at least with D3D11, for some reason it doesn't seem to affect Vulkan and GLcore 🤷 ):

* With a value of "4": 
![image](https://user-images.githubusercontent.com/33353403/132142848-4c22c332-1e90-4dd8-9073-add8f14dd91e.png)
* With a value of "16": 
![image](https://user-images.githubusercontent.com/33353403/132142854-1b6fffc0-ea84-400b-81f9-2fb8e28b6b4a.png)

This is because there should be only 5 values possible in `GFX.ini`:

* "0" for "1x".
* "1" for "2x".
* "2" for "4x".
* "3" for "8x".
* "4" for "16x".

So you're never supposed to have a value above "4" in the .ini but currently it can go up to "16"...

Anyway, this simple PR fixes this, tested with 007 - Nightfire and it works fine, here's some 300% zoom screenshots (clickable):

1x | 2x
:-:|:-:
![image](https://user-images.githubusercontent.com/33353403/132142941-7a39a780-ef6c-48c9-acbe-17f6f47158b5.png) | ![image](https://user-images.githubusercontent.com/33353403/132142947-aeb3e0cd-707c-4408-84f5-dc9f74d41648.png)
4x | 8x
![image](https://user-images.githubusercontent.com/33353403/132142960-75bbffe2-aeee-49e8-8777-942c49e97e8d.png) | ![image](https://user-images.githubusercontent.com/33353403/132142969-8ecf7e96-0ed1-4e5e-862e-6cb631ba63e0.png)
16x |
![image](https://user-images.githubusercontent.com/33353403/132142991-aa85e1f7-2761-4a87-9e11-1918734ee7f0.png)
