### PR TITLE
Fixes sound issues in RE2 and 3.

### DIFF
--- a/Data/Sys/GameSettings/GHAE08.ini
+++ b/Data/Sys/GameSettings/GHAE08.ini
@@ -1,0 +1,16 @@
+# GHAE08 - Resident Evil 2
+
+[OnFrame]
+# Work around a game bug that causes background sounds to be zeroed during load.
+# The bug was masked on real hardware by dcache. This patch fully fixes the bug
+# and should also work on real hardware. Dolphin doesn't emulate dcache because
+# the performance hit would be huge.
+$Fix audio issues
+# main.dol
+0x800339E4:dword:0x60000000
+# leon.rel
+0x8055ACBC:dword:0x60000000:0x4BAA8445
+# claire.rel
+0x8055AB54:dword:0x60000000:0x4BAA85AD
+[OnFrame_Enabled]
+$Fix audio issues

--- a/Data/Sys/GameSettings/GHAJ08.ini
+++ b/Data/Sys/GameSettings/GHAJ08.ini
@@ -1,0 +1,16 @@
+# GHAJ08 - Biohazard 2
+
+[OnFrame]
+# Work around a game bug that causes background sounds to be zeroed during load.
+# The bug was masked on real hardware by dcache. This patch fully fixes the bug
+# and should also work on real hardware. Dolphin doesn't emulate dcache because
+# the performance hit would be huge.
+$Fix audio issues
+# main.dol
+0x80065FFC:dword:0x60000000
+# leon.rel
+0x805C5CC4:dword:0x60000000:0x4BA3D43D
+# claire.rel
+0x805C5BFC:dword:0x60000000:0x4BA3D505
+[OnFrame_Enabled]
+$Fix audio issues

--- a/Data/Sys/GameSettings/GHAP08.ini
+++ b/Data/Sys/GameSettings/GHAP08.ini
@@ -1,0 +1,32 @@
+# GHAP08 - Resident Evil 2
+
+[OnFrame]
+# Work around a game bug that causes background sounds to be zeroed during load.
+# The bug was masked on real hardware by dcache. This patch fully fixes the bug
+# and should also work on real hardware. Dolphin doesn't emulate dcache because
+# the performance hit would be huge.
+$Fix audio issues
+# main.dol
+0x80033D60:dword:0x60000000
+# leon.rel
+0x8055C5F8:dword:0x60000000:0x4BAA6B09
+# claire.rel
+0x8055C490:dword:0x60000000:0x4BAA6C71
+# leon_g.rel
+0x8055C3B8:dword:0x60000000:0x4BAA6D49
+# claire_g.rel
+0x8055C328:dword:0x60000000:0x4BAA6DD9
+# leon_f.rel
+0x8055D188:dword:0x60000000:0x4BAA5F79
+# claire_f.rel
+0x8055D068:dword:0x60000000:0x4BAA6099
+# leon_s.rel
+0x8055D100:dword:0x60000000:0x4BAA6001
+# claire_s.rel
+0x8055D064:dword:0x60000000:0x4BAA609D
+# leon_i.rel
+0x8055CFDC:dword:0x60000000:0x4BAA6125
+# claire_i.rel
+0x8055CEBC:dword:0x60000000:0x4BAA6245
+[OnFrame_Enabled]
+$Fix audio issues

--- a/Data/Sys/GameSettings/GLEE08.ini
+++ b/Data/Sys/GameSettings/GLEE08.ini
@@ -1,0 +1,12 @@
+# GLEE08 - Resident Evil 3: Nemesis
+
+[OnFrame]
+# Work around a game bug that causes background sounds to be zeroed during load.
+# The bug was masked on real hardware by dcache. This patch fully fixes the bug
+# and should also work on real hardware. Dolphin doesn't emulate dcache because
+# the performance hit would be huge.
+$Fix audio issues
+# main.dol
+0x80150E94:dword:0x60000000
+[OnFrame_Enabled]
+$Fix audio issues

--- a/Data/Sys/GameSettings/GLEJ08.ini
+++ b/Data/Sys/GameSettings/GLEJ08.ini
@@ -1,0 +1,12 @@
+# GLEJ08 - BioHazard 3: Last Escape
+
+[OnFrame]
+# Work around a game bug that causes background sounds to be zeroed during load.
+# The bug was masked on real hardware by dcache. This patch fully fixes the bug
+# and should also work on real hardware. Dolphin doesn't emulate dcache because
+# the performance hit would be huge.
+$Fix audio issues
+# main.dol
+0x8015110C:dword:0x60000000
+[OnFrame_Enabled]
+$Fix audio issues

--- a/Data/Sys/GameSettings/GLEP08.ini
+++ b/Data/Sys/GameSettings/GLEP08.ini
@@ -1,0 +1,20 @@
+# GLEP08 - Resident Evil 3: Nemesis
+
+[OnFrame]
+# Work around a game bug that causes background sounds to be zeroed during load.
+# The bug was masked on real hardware by dcache. This patch fully fixes the bug
+# and should also work on real hardware. Dolphin doesn't emulate dcache because
+# the performance hit would be huge.
+$Fix audio issues
+# eng.rel
+0x8058C174:dword:0x60000000:0x4BA76F8D
+# ger.rel
+0x8058CE40:dword:0x60000000:0x4BA762C1
+# fra.rel
+0x8058D03C:dword:0x60000000:0x4BA760C5
+# spa.rel
+0x8058D024:dword:0x60000000:0x4BA760DD
+# ita.rel
+0x8058CEA4:dword:0x60000000:0x4BA7625D
+[OnFrame_Enabled]
+$Fix audio issues

--- a/Source/Core/Core/PatchEngine.h
+++ b/Source/Core/Core/PatchEngine.h
@@ -27,6 +27,8 @@ struct PatchEntry
   PatchType type = PatchType::Patch8Bit;
   u32 address = 0;
   u32 value = 0;
+  u32 comparand = 0;
+  bool conditional = false;
 };
 
 struct Patch


### PR DESCRIPTION
Backport of https://github.com/dolphin-emu/dolphin/commit/4cdcbb6ab28596653635ab91b1ccd0332629925a minus the DolphinQt stuff.

Users will have to update their Dolphin assets for these 2 games to work properly, since the fix relies on the .ini files.

Closes #55