### PR TITLE
Allow patches to be auto-loaded

### DIFF
--- a/Data/Sys/GameSettings/GV4E69.ini
+++ b/Data/Sys/GameSettings/GV4E69.ini
@@ -1,0 +1,7 @@
+# GV4E69 - MVP Baseball 2005
+
+[OnFrame]
+$Fix 2D Rendering
+0x80319214:dword:0x48113250
+[OnFrame_Enabled]
+$Fix 2D Rendering

--- a/Data/Sys/GameSettings/GVPE69.ini
+++ b/Data/Sys/GameSettings/GVPE69.ini
@@ -1,0 +1,7 @@
+# GVPE69 - MVP Baseball 2004
+
+[OnFrame]
+$Fix 2D Rendering
+0x803C92D4:dword:0x480DA8E4
+[OnFrame_Enabled]
+$Fix 2D Rendering

--- a/Data/Sys/GameSettings/GWLE6L.ini
+++ b/Data/Sys/GameSettings/GWLE6L.ini
@@ -3,3 +3,5 @@
 [OnFrame]
 $Bypass FIFO reset
 0x8028EF00:dword:0x48000638
+[OnFrame_Enabled]
+$Bypass FIFO reset

--- a/Data/Sys/GameSettings/GWLX6L.ini
+++ b/Data/Sys/GameSettings/GWLX6L.ini
@@ -3,3 +3,5 @@
 [OnFrame]
 $Bypass FIFO reset
 0x8028EE80:dword:0x48000638
+[OnFrame_Enabled]
+$Bypass FIFO reset

--- a/Data/Sys/GameSettings/RX4E4Z.ini
+++ b/Data/Sys/GameSettings/RX4E4Z.ini
@@ -24,3 +24,5 @@
 #
 $Fix file reads (dcache bypass)
 0x800d2e68:dword:0x60000000
+[OnFrame_Enabled]
+$Fix file reads (dcache bypass)

--- a/Data/Sys/GameSettings/RX4PMT.ini
+++ b/Data/Sys/GameSettings/RX4PMT.ini
@@ -24,3 +24,5 @@
 #
 $Fix file reads (dcache bypass)
 0x80164b90:dword:0x60000000
+[OnFrame_Enabled]
+$Fix file reads (dcache bypass)

--- a/Source/Core/Core/ActionReplay.cpp
+++ b/Source/Core/Core/ActionReplay.cpp
@@ -26,7 +26,6 @@
 #include <iterator>
 #include <mutex>
 #include <string>
-#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -39,6 +38,7 @@
 #include "Common/MsgHandler.h"
 
 #include "Core/ARDecrypt.h"
+#include "Core/CheatCodes.h"
 #include "Core/ConfigManager.h"
 #include "Core/PowerPC/MMU.h"
 
@@ -120,7 +120,7 @@ void ApplyCodes(const std::vector<ARCode>& codes)
   s_disable_logging = false;
   s_active_codes.clear();
   std::copy_if(codes.begin(), codes.end(), std::back_inserter(s_active_codes),
-               [](const ARCode& code) { return code.active; });
+               [](const ARCode& code) { return code.enabled; });
   s_active_codes.shrink_to_fit();
 }
 
@@ -136,7 +136,7 @@ void UpdateSyncedCodes(const std::vector<ARCode>& codes)
   s_synced_codes.clear();
   s_synced_codes.reserve(codes.size());
   std::copy_if(codes.begin(), codes.end(), std::back_inserter(s_synced_codes),
-               [](const ARCode& code) { return code.active; });
+               [](const ARCode& code) { return code.enabled; });
   s_synced_codes.shrink_to_fit();
 }
 
@@ -148,7 +148,7 @@ std::vector<ARCode> ApplyAndReturnCodes(const std::vector<ARCode>& codes)
     s_disable_logging = false;
     s_active_codes.clear();
     std::copy_if(codes.begin(), codes.end(), std::back_inserter(s_active_codes),
-                 [](const ARCode& code) { return code.active; });
+                 [](const ARCode& code) { return code.enabled; });
   }
   s_active_codes.shrink_to_fit();
 
@@ -160,7 +160,7 @@ void AddCode(ARCode code)
   if (!SConfig::GetInstance().bEnableCheats)
     return;
 
-  if (code.active)
+  if (code.enabled)
   {
     std::lock_guard<std::mutex> guard(s_lock);
     s_disable_logging = false;
@@ -177,20 +177,6 @@ void LoadAndApplyCodes(const IniFile& global_ini, const IniFile& local_ini)
 std::vector<ARCode> LoadCodes(const IniFile& global_ini, const IniFile& local_ini)
 {
   std::vector<ARCode> codes;
-
-  std::unordered_set<std::string> enabled_names;
-  {
-    std::vector<std::string> enabled_lines;
-    local_ini.GetLines("ActionReplay_Enabled", &enabled_lines);
-    for (const std::string& line : enabled_lines)
-    {
-      if (!line.empty() && line[0] == '$')
-      {
-        std::string name = line.substr(1, line.size() - 1);
-        enabled_names.insert(name);
-      }
-    }
-  }
 
   const IniFile* inis[2] = {&global_ini, &local_ini};
   for (const IniFile* ini : inis)
@@ -225,7 +211,6 @@ std::vector<ARCode> LoadCodes(const IniFile& global_ini, const IniFile& local_in
         }
 
         current_code.name = line.substr(1, line.size() - 1);
-        current_code.active = enabled_names.find(current_code.name) != enabled_names.end();
         current_code.user_defined = (ini == &local_ini);
       }
       else
@@ -279,6 +264,14 @@ std::vector<ARCode> LoadCodes(const IniFile& global_ini, const IniFile& local_in
       DecryptARCode(encrypted_lines, &current_code.ops);
       codes.push_back(current_code);
     }
+
+    ReadEnabledAndDisabled(*ini, "ActionReplay", &codes);
+
+    if (ini == &global_ini)
+    {
+      for (ARCode& code : codes)
+        code.default_enabled = code.enabled;
+    }
   }
 
   return codes;
@@ -288,21 +281,27 @@ void SaveCodes(IniFile* local_ini, const std::vector<ARCode>& codes)
 {
   std::vector<std::string> lines;
   std::vector<std::string> enabled_lines;
+  std::vector<std::string> disabled_lines;
+
   for (const ActionReplay::ARCode& code : codes)
   {
-    if (code.active)
-      enabled_lines.emplace_back("$" + code.name);
+    if (code.enabled)
+      enabled_lines.emplace_back('$' + code.name);
+    else if (code.default_enabled)
+      disabled_lines.emplace_back('$' + code.name);
 
     if (code.user_defined)
     {
-      lines.emplace_back("$" + code.name);
+      lines.emplace_back('$' + code.name);
       for (const ActionReplay::AREntry& op : code.ops)
       {
         lines.emplace_back(fmt::format("{:08X} {:08X}", op.cmd_addr, op.value));
       }
     }
   }
+
   local_ini->SetLines("ActionReplay_Enabled", enabled_lines);
+  local_ini->SetLines("ActionReplay_Disabled", disabled_lines);
   local_ini->SetLines("ActionReplay", lines);
 }
 

--- a/Source/Core/Core/ActionReplay.h
+++ b/Source/Core/Core/ActionReplay.h
@@ -28,8 +28,9 @@ struct ARCode
 {
   std::string name;
   std::vector<AREntry> ops;
-  bool active;
-  bool user_defined;
+  bool enabled = false;
+  bool default_enabled = false;
+  bool user_defined = false;
 };
 
 void RunAllActive();

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(core
   ARDecrypt.h
   BootManager.cpp
   BootManager.h
+  CheatCodes.h
   CommonTitles.h
   ConfigManager.cpp
   ConfigManager.h

--- a/Source/Core/Core/CheatCodes.h
+++ b/Source/Core/Core/CheatCodes.h
@@ -1,0 +1,38 @@
+// Copyright 2020 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "Common/IniFile.h"
+
+template <typename T>
+void ReadEnabledOrDisabled(const IniFile& ini, const std::string& section, bool enabled,
+                           std::vector<T>* codes)
+{
+  std::vector<std::string> lines;
+  ini.GetLines(section, &lines, false);
+
+  for (const std::string& line : lines)
+  {
+    if (line.empty() || line[0] != '$')
+      continue;
+
+    for (T& code : *codes)
+    {
+      // Exclude the initial '$' from the comparison.
+      if (line.compare(1, std::string::npos, code.name) == 0)
+        code.enabled = enabled;
+    }
+  }
+}
+
+template <typename T>
+void ReadEnabledAndDisabled(const IniFile& ini, const std::string& section, std::vector<T>* codes)
+{
+  ReadEnabledOrDisabled(ini, section + "_Enabled", true, codes);
+  ReadEnabledOrDisabled(ini, section + "_Disabled", false, codes);
+}

--- a/Source/Core/Core/Core.vcxproj
+++ b/Source/Core/Core/Core.vcxproj
@@ -383,6 +383,7 @@
     <ClInclude Include="Boot\DolReader.h" />
     <ClInclude Include="Boot\ElfReader.h" />
     <ClInclude Include="Boot\ElfTypes.h" />
+    <ClInclude Include="CheatCodes.h" />
     <ClInclude Include="Config\GraphicsSettings.h" />
     <ClInclude Include="Config\MainSettings.h" />
     <ClInclude Include="Config\NetplaySettings.h" />

--- a/Source/Core/Core/Core.vcxproj.filters
+++ b/Source/Core/Core/Core.vcxproj.filters
@@ -1758,6 +1758,7 @@
     <ClInclude Include="HW\EXI\BBA\TAP_Win32.h">
       <Filter>HW %28Flipper/Hollywood%29\EXI - Expansion Interface\BBA</Filter>
     </ClInclude>
+    <ClInclude Include="CheatCodes.h" />
   </ItemGroup>
   <ItemGroup>
     <Text Include="CMakeLists.txt" />

--- a/Source/Core/Core/GeckoCode.h
+++ b/Source/Core/Core/GeckoCode.h
@@ -28,8 +28,9 @@ public:
   std::string name, creator;
   std::vector<std::string> notes;
 
-  bool enabled;
-  bool user_defined;
+  bool enabled = false;
+  bool default_enabled = false;
+  bool user_defined = false;
 
   bool Exist(u32 address, u32 data) const;
 };

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -1136,7 +1136,7 @@ unsigned int NetPlayClient::OnData(sf::Packet& packet)
       arcode = ActionReplay::ARCode();
       // Initialize arcode
       arcode.name = "Synced Codes";
-      arcode.active = true;
+      arcode.enabled = true;
 
       // Receive code contents from packet
       for (int i = 0; i < m_sync_ar_codes_count; i++)

--- a/Source/Core/Core/PatchEngine.h
+++ b/Source/Core/Core/PatchEngine.h
@@ -35,7 +35,8 @@ struct Patch
 {
   std::string name;
   std::vector<PatchEntry> entries;
-  bool active = false;
+  bool enabled = false;
+  bool default_enabled = false;
   bool user_defined = false;  // False if this code is shipped with Dolphin.
 };
 


### PR DESCRIPTION
Backport of https://github.com/dolphin-emu/dolphin/commit/7d9276c3401d99d601bcd6fb1ca1e2c9cd4a3e97 (minus the DolphinQt stuff once again). Not sure if the cmake and vcxproj changes are needed for us but I've added them anyway to be safe.

As mentioned in #230 the RE2/3 patches work fine from the User folder but not from the Sys, this backport allows patches to be auto-loaded (if they're enabled in the .ini of course). Tested with RE2/3, MVP Baseball 2005 (the .ini being added in this commit) and a couple other games, seems to work fine.