### PR TITLE
Fix real Wiimote

### DIFF
--- a/Source/Core/DolphinLibretro/Input.cpp
+++ b/Source/Core/DolphinLibretro/Input.cpp
@@ -804,6 +804,7 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
 
     case RETRO_DEVICE_REAL_WIIMOTE:
       WiimoteCommon::SetSource(port, WiimoteSource::Real);
+      break;
 
     default:
       WiimoteCommon::SetSource(port, WiimoteSource::None);
@@ -837,6 +838,7 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
       desc = Libretro::Input::descWiimoteCCPro;
       break;
 
+    case RETRO_DEVICE_REAL_WIIMOTE:
     case RETRO_DEVICE_NONE:
       continue;
 


### PR DESCRIPTION
Yup, looks like all this time it was broken because of a missing break...

Tested with a few games with a Dolphin Bar, works fine AFAICT :) Still needs the "Continuous Scanning" core option ON to "pair" the Wiimote.