### PR TITLE
Input fixes/improvements

### DIFF
--- a/Source/Core/DolphinLibretro/Main.cpp
+++ b/Source/Core/DolphinLibretro/Main.cpp
@@ -145,7 +145,6 @@ void retro_get_system_info(retro_system_info* info)
 
 void retro_get_system_av_info(retro_system_av_info* info)
 {
-  unsigned efb_scale         = Libretro::Options::efbScale;
   info->geometry.base_width  = EFB_WIDTH * Libretro::Options::efbScale;
   info->geometry.base_height = EFB_HEIGHT * Libretro::Options::efbScale;
 

--- a/Source/Core/DolphinLibretro/Options.cpp
+++ b/Source/Core/DolphinLibretro/Options.cpp
@@ -210,6 +210,7 @@ Option<bool> enableRumble("dolphin_enable_rumble", "Rumble", true);
 Option<u32> sensorBarPosition("dolphin_sensor_bar_position", "Sensor Bar Position",
                               {"Bottom", "Top"});
 Option<bool> WiimoteContinuousScanning("dolphin_wiimote_continuous_scanning", "Wiimote Continuous Scanning", false);
+Option<bool> altGCPorts("dolphin_alt_gc_ports_on_wii", "Use ports 5-8 for GameCube controllers in Wii mode", false);
 Option<unsigned int> audioMixerRate("dolphin_mixer_rate", "Audio Mixer Rate",
                                     {{"32000", 32000u}, {"48000", 48000u}});
 Option<bool> DSPHLE("dolphin_dsp_hle", "DSP HLE", true);

--- a/Source/Core/DolphinLibretro/Options.h
+++ b/Source/Core/DolphinLibretro/Options.h
@@ -117,6 +117,7 @@ extern Option<int> irHeight;
 extern Option<bool> enableRumble;
 extern Option<u32> sensorBarPosition;
 extern Option<bool> WiimoteContinuousScanning;
+extern Option<bool> altGCPorts;
 extern Option<unsigned int> audioMixerRate;
 extern Option<bool> DSPHLE;
 extern Option<bool> DSPEnableJIT;


### PR DESCRIPTION
* Fixed the issue where you had to manually edit `Dolphin.ini` to enable GC controllers 2-4.
* Added the possibility to un/plug Wiimotes or GC controllers on-the-fly. Previously not possible with GC controllers, and it was messing with the players order if Wiimotes were not reconnected in the correct order.
* Added the possibility to use GC controller as players 1-4 in Wii mode. Makes it possible to play Brawl, MK Wii, etc. with a GC layout.
* Fix Wiimotes displaying GC labels by default.
* (not related to inputs) Removed the unused "efb_scale" variable. It was harmless but that's one less warning during compilation :p 

For the 3rd point, I added a core option to put the GC controllers on ports 5-8 in Wii mode, when it's ON the GC controller is a selectable device type for ports 5-8, just like it was before this PR. When the option is OFF the GC controller is selectable in ports 1-4 instead and ports 5-8 are unused. The option is set to OFF by default since AFAIK it's only useful for Bomberman Blast when playing 5+ players modes.

Using GC controller as device type in ports 1-4 is used way more often, games like Super Smash Bros. Brawl, Mario Kart Wii, DBZ Budokai Tenkaichi 2 and 3, Sonic Colors and others (see https://en.wikipedia.org/wiki/List_of_Wii_games_with_traditional_control_schemes) can now be played with the GC layout by simply switching the device type!

As I said multiple times I'm not a dev so most of this stuff took me forever to understand by myself... There's ~~maybe~~ probably a better/cleaner way to handle that stuff, I just got a bit frustrated with these issues and since no one seemed available to fix them I thought I could give it a try! From the ton of testing I made (mixing both Wiimotes and GC controllers, testing multiple games, different numbers of ports, including a real Wiimote, etc.) it works fine.

Quick video showing `Dolphin.ini` being updated properly even after disconnecting/reconnecting GC controllers in Melee, then messing with Wiimotes and GC controllers in Brawl to show the "new" device type in action:

https://user-images.githubusercontent.com/33353403/145906014-26ac4cd7-624a-45e8-8526-94cdb57f458b.mp4

This closes #217 and #163

**edit:** Compiled core for Windows and Linux 64bit if anyone is curious but don't know how or can't build the core: https://github.com/bslenul/dolphin/releases/tag/various-input-fixes

**edit2:** Added some comments + minor tweaks.