### PR TITLE
remove CPUThread = False from all GameSettings inis to prevent crashing

### DIFF
--- a/Data/Sys/GameSettings/E5Z.ini
+++ b/Data/Sys/GameSettings/E5Z.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/E62.ini
+++ b/Data/Sys/GameSettings/E62.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/E63.ini
+++ b/Data/Sys/GameSettings/E63.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/E6W.ini
+++ b/Data/Sys/GameSettings/E6W.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/E6X.ini
+++ b/Data/Sys/GameSettings/E6X.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/G4Z.ini
+++ b/Data/Sys/GameSettings/G4Z.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/G96.ini
+++ b/Data/Sys/GameSettings/G96.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GGC.ini
+++ b/Data/Sys/GameSettings/GGC.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GIS.ini
+++ b/Data/Sys/GameSettings/GIS.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-CPUThread = False
 MMU = 1
 
 [OnLoad]

--- a/Data/Sys/GameSettings/GSN.ini
+++ b/Data/Sys/GameSettings/GSN.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GT3.ini
+++ b/Data/Sys/GameSettings/GT3.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GWT.ini
+++ b/Data/Sys/GameSettings/GWT.ini
@@ -5,7 +5,6 @@
 # This game does not work properly with large memorycards, use a 251 block card
 # see https://www.nintendo.com/consumer/memorycard1019.jsp
 MemoryCard251 = True
-CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/R5P.ini
+++ b/Data/Sys/GameSettings/R5P.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/RDZ.ini
+++ b/Data/Sys/GameSettings/RDZ.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/RG4.ini
+++ b/Data/Sys/GameSettings/RG4.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/RH6.ini
+++ b/Data/Sys/GameSettings/RH6.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/RHA.ini
+++ b/Data/Sys/GameSettings/RHA.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/RHO.ini
+++ b/Data/Sys/GameSettings/RHO.ini
@@ -1,7 +1,6 @@
 # RHOE8P, RHOJ8P, RHOP8P - House Of The Dead: OVERKILL
 [Core]
 # Values set here will override the main Dolphin settings.
-CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/RNB.ini
+++ b/Data/Sys/GameSettings/RNB.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/RSP.ini
+++ b/Data/Sys/GameSettings/RSP.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/RTB.ini
+++ b/Data/Sys/GameSettings/RTB.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-CPUThread = False
 
 [Video_Settings]
 SuggestedAspectRatio = 2

--- a/Data/Sys/GameSettings/SCI.ini
+++ b/Data/Sys/GameSettings/SCI.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/WD9.ini
+++ b/Data/Sys/GameSettings/WD9.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/WKT.ini
+++ b/Data/Sys/GameSettings/WKT.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.


### PR DESCRIPTION
A workaround for https://github.com/libretro/dolphin/issues/235

I used the command:

`sed -i.bak '/CPUThread = False/d' *`

to remove the offending lines. We'll presumably need to do this again if we resync against upstream (and don't fix the actual problem).