### PR TITLE
Twilight Princess - Enable the "Hyrule Field Speed Hack" by default

### DIFF
--- a/Data/Sys/GameSettings/GZ2E01.ini
+++ b/Data/Sys/GameSettings/GZ2E01.ini
@@ -39,6 +39,9 @@ $Hyrule Field Speed Hack
 0x8003D5EC:dword:0x60000000
 0x8003D608:dword:0x60000000
 
+[OnFrame_Enabled]
+$Hyrule Field Speed Hack
+
 [ActionReplay]
 # Add action replay cheats here.
 $Infinite Health

--- a/Data/Sys/GameSettings/GZ2J01.ini
+++ b/Data/Sys/GameSettings/GZ2J01.ini
@@ -35,3 +35,6 @@ $Hyrule Field Speed Hack
 0x8003D5D4:dword:0x60000000
 0x8003D5EC:dword:0x60000000
 0x8003D608:dword:0x60000000
+
+[OnFrame_Enabled]
+$Hyrule Field Speed Hack

--- a/Data/Sys/GameSettings/GZ2P01.ini
+++ b/Data/Sys/GameSettings/GZ2P01.ini
@@ -39,6 +39,9 @@ $Hyrule Field Speed Hack
 0x8003d71c:dword:0x60000000
 0x8003d738:dword:0x60000000
 
+[OnFrame_Enabled]
+$Hyrule Field Speed Hack
+
 [ActionReplay]
 # Add action replay cheats here.
 $Infinite Health


### PR DESCRIPTION
Hey, so in Twilight Princess when you're in the open world part of the game it runs like crap, there's a hack for it but it's disabled by default because it messes slightly with the minimap: https://wiki.dolphin-emu.org/index.php?title=The_Legend_of_Zelda:_Twilight_Princess_(GC)#Hyrule_Field_Speed_Hack

On standalone that's not a big deal as it's only a box to check, on RA however it's a bit more tricky for the user to enable it (it requires to edit or create a .ini file) so IMO it'd be better to have it enabled by default. The framerate is much more important than shadows missing on the minimap, and tbh probably no one will even notice it :p 