### PR TITLE
Update VulkanContext.cpp

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -892,6 +892,11 @@ void VulkanContext::InitDriverDetails()
     vendor = DriverDetails::VENDOR_IMGTEC;
     driver = DriverDetails::DRIVER_IMGTEC;
   }
+    else if (vendor_id == 0x14E4 || device_name.find("V3D 4.2") != std::string::npos)
+  {
+    vendor = DriverDetails::VENDOR_MESA;
+    driver = DriverDetails::DRIVER_V3D;
+  }
   else
   {
     WARN_LOG(VIDEO, "Unknown Vulkan driver vendor, please report it to us.");


### PR DESCRIPTION
Added vendor and device descriptors for the mesa vulkan driver for the Broadcom VideoCore  found in the raspberry pi 4 and newer.