### PR TITLE
Broadcom videocore IV vulkan support

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -892,6 +892,12 @@ void VulkanContext::InitDriverDetails()
     vendor = DriverDetails::VENDOR_IMGTEC;
     driver = DriverDetails::DRIVER_IMGTEC;
   }
+    else if (vendor_id == 0x14E4 || device_name.find("V3D 4.2") != std::string::npos)
+  {
+    // Supported by the videocore IV found in the RPI4 and upwards.
+    vendor = DriverDetails::VENDOR_MESA;
+    driver = DriverDetails::DRIVER_V3D;
+  }
   else
   {
     WARN_LOG(VIDEO, "Unknown Vulkan driver vendor, please report it to us.");

--- a/Source/Core/VideoCommon/DriverDetails.h
+++ b/Source/Core/VideoCommon/DriverDetails.h
@@ -61,6 +61,7 @@ enum Driver
   DRIVER_FREEDRENO,    // OSS Adreno driver
   DRIVER_IMGTEC,       // Official PowerVR driver
   DRIVER_VIVANTE,      // Official Vivante driver
+  DRIVER_V3D,          // OSS Broadcom driver
   DRIVER_PORTABILITY,  // Vulkan via Metal on macOS
   DRIVER_UNKNOWN       // Unknown driver, default to official hardware driver
 };


### PR DESCRIPTION
Add Vendor and Device descriptors for the Mesa22 V3D vulkan driver for the broadcom videocore IV.
Supported by the raspberry pi 4 onwards.