### PR TITLE
Add a dupe frames core option

### DIFF
--- a/Source/Core/DolphinLibretro/Boot.cpp
+++ b/Source/Core/DolphinLibretro/Boot.cpp
@@ -121,6 +121,7 @@ bool retro_load_game(const struct retro_game_info* game)
   Config::SetBase(Config::GFX_BACKEND_MULTITHREADING, false);
   Config::SetBase(Config::GFX_SHADER_COMPILATION_MODE, Libretro::Options::shaderCompilationMode);
   Config::SetBase(Config::GFX_ENHANCE_MAX_ANISOTROPY, Libretro::Options::maxAnisotropy);
+  Config::SetBase(Config::GFX_HACK_SKIP_DUPLICATE_XFBS, Libretro::Options::skipDupeFrames);
   Config::SetBase(Config::GFX_HACK_COPY_EFB_SCALED, Libretro::Options::efbScaledCopy);
   Config::SetBase(Config::GFX_HACK_SKIP_EFB_COPY_TO_RAM, Libretro::Options::efbToTexture);
   Config::SetBase(Config::GFX_HACK_DISABLE_COPY_TO_VRAM, Libretro::Options::efbToVram);

--- a/Source/Core/DolphinLibretro/Options.cpp
+++ b/Source/Core/DolphinLibretro/Options.cpp
@@ -132,6 +132,7 @@ Option<bool> waitForShaders("dolphin_wait_for_shaders", "Wait for Shaders before
 Option<bool> progressiveScan("dolphin_progressive_scan", "Progressive Scan", true);
 Option<bool> pal60("dolphin_pal60", "PAL60", true);
 Option<int> maxAnisotropy("dolphin_max_anisotropy", "Max Anisotropy", {"1x", "2x", "4x", "8x", "16x"});
+Option<bool> skipDupeFrames("dolphin_skip_dupe_frames", "Skip Presenting Duplicate Frames", true);
 Option<bool> efbScaledCopy("dolphin_efb_scaled_copy", "Scaled EFB Copy", true);
 Option<bool> forceTextureFiltering("dolphin_force_texture_filtering", "Force Texture Filtering", false);
 Option<bool> efbToTexture("dolphin_efb_to_texture", "Store EFB Copies on GPU", true);

--- a/Source/Core/DolphinLibretro/Options.h
+++ b/Source/Core/DolphinLibretro/Options.h
@@ -98,6 +98,7 @@ extern Option<bool> waitForShaders;
 extern Option<bool> progressiveScan;
 extern Option<bool> pal60;
 extern Option<int> maxAnisotropy;
+extern Option<bool> skipDupeFrames;
 extern Option<bool> efbScaledCopy;
 extern Option<bool> forceTextureFiltering;
 extern Option<bool> efbToTexture;


### PR DESCRIPTION
Expose the "Skip Presenting Duplicate Frames" hack in the core options, tested with Wind Waker (a 30fps game) with Vulkan and D3D11, seems to work fine:

* ON: 
![image](https://user-images.githubusercontent.com/33353403/162247331-25bd6e4c-eb68-4790-923f-f73a9392add9.png)

* OFF: 
![image](https://user-images.githubusercontent.com/33353403/162247379-53389f63-3a8f-499d-80c5-4a6b2054efe1.png)
