### PR TITLE
Expose "Prefetch Custom Textures" core option

### DIFF
--- a/Source/Core/DolphinLibretro/Boot.cpp
+++ b/Source/Core/DolphinLibretro/Boot.cpp
@@ -131,6 +131,7 @@ bool retro_load_game(const struct retro_game_info* game)
   Config::SetBase(Config::GFX_WAIT_FOR_SHADERS_BEFORE_STARTING, Libretro::Options::waitForShaders);
   Config::SetBase(Config::GFX_ENHANCE_FORCE_FILTERING, Libretro::Options::forceTextureFiltering);
   Config::SetBase(Config::GFX_HIRES_TEXTURES, Libretro::Options::loadCustomTextures);
+  Config::SetBase(Config::GFX_CACHE_HIRES_TEXTURES, Libretro::Options::cacheCustomTextures);
   Config::SetBase(Config::GFX_SAFE_TEXTURE_CACHE_COLOR_SAMPLES, Libretro::Options::textureCacheAccuracy);
 #if 0
   Config::SetBase(Config::GFX_SHADER_COMPILER_THREADS, 1);

--- a/Source/Core/DolphinLibretro/Options.cpp
+++ b/Source/Core/DolphinLibretro/Options.cpp
@@ -143,6 +143,7 @@ Option<bool> fastDepthCalc("dolphin_fast_depth_calculation", "Fast Depth Calcula
 Option<bool> bboxEnabled("dolphin_bbox_enabled", "Bounding Box Emulation", false);
 Option<bool> efbToVram("dolphin_efb_to_vram", "Disable EFB to VRAM", false);
 Option<bool> loadCustomTextures("dolphin_load_custom_textures", "Load Custom Textures", false);
+Option<bool> cacheCustomTextures("dolphin_cache_custom_textures", "Prefetch Custom Textures", false);
 Option<PowerPC::CPUCore> cpu_core("dolphin_cpu_core", "CPU Core",
                                   {
 #ifdef _M_X86

--- a/Source/Core/DolphinLibretro/Options.h
+++ b/Source/Core/DolphinLibretro/Options.h
@@ -108,6 +108,7 @@ extern Option<bool> fastDepthCalc;
 extern Option<bool> bboxEnabled;
 extern Option<bool> efbToVram;
 extern Option<bool> loadCustomTextures;
+extern Option<bool> cacheCustomTextures;
 extern Option<PowerPC::CPUCore> cpu_core;
 extern Option<float> cpuClockRate;
 extern Option<bool> fastmem;


### PR DESCRIPTION
Tested with 2 texture packs:

* Metroid Prime:

![image](https://user-images.githubusercontent.com/33353403/175022463-2d4bce87-72bd-421f-b610-286fda8195d8.png)

* Resident Evil 2:

![image](https://user-images.githubusercontent.com/33353403/175022522-d60696e2-78db-49d2-9db5-d2dc196bb3dd.png)

Pretty long for RE2 but the pack is huge and my PC is getting old so my RAM isn't the fastest :p But it works.

Closes #273