### PR TITLE
BlendingState: Set source and destination alpha factors in logic op workaround

### DIFF
--- a/Source/Core/VideoCommon/RenderState.cpp
+++ b/Source/Core/VideoCommon/RenderState.cpp
@@ -200,7 +200,9 @@ void BlendingState::ApproximateLogicOpWithBlending()
   blendenable = true;
   subtract = approximations[logicmode].subtract;
   srcfactor = approximations[logicmode].srcfactor;
+  srcfactoralpha = approximations[logicmode].srcfactor;
   dstfactor = approximations[logicmode].dstfactor;
+  dstfactoralpha = approximations[logicmode].dstfactor;
 }
 
 BlendingState& BlendingState::operator=(const BlendingState& rhs)


### PR DESCRIPTION
Kirby's Air Ride uses the alpha value as a multiplier for the pixel's color in shadow rendering. If we don't update it, then the alpha ends up being set to 0 for the entire frame, causing the entire world to be shadowed in darkness as every color gets multiplied by zero.

The FifoCI diff can be found [here](https://fifo.ci/compare/7365753-7365499/). Doesn't seem to affect any other games.

Fixes Kirby's Air Ride on Intel Macs.