### PR TITLE
Add anti-aliasing option

### DIFF
--- a/Source/Core/DolphinLibretro/Boot.cpp
+++ b/Source/Core/DolphinLibretro/Boot.cpp
@@ -139,6 +139,38 @@ bool retro_load_game(const struct retro_game_info* game)
   Config::SetBase(Config::GFX_SHADER_PRECOMPILER_THREADS, 1);
 #endif
 
+  switch (Libretro::Options::antiAliasing)
+  {
+    case 1:  // 2x MSAA
+      Config::SetBase(Config::GFX_MSAA, 2);
+      Config::SetBase(Config::GFX_SSAA, false);
+      break;
+    case 2:  // 4x MSAA
+      Config::SetBase(Config::GFX_MSAA, 4);
+      Config::SetBase(Config::GFX_SSAA, false);
+      break;
+    case 3:  // 8x MSAA
+      Config::SetBase(Config::GFX_MSAA, 8);
+      Config::SetBase(Config::GFX_SSAA, false);
+      break;
+    case 4:  // 2x SSAA
+      Config::SetBase(Config::GFX_MSAA, 2);
+      Config::SetBase(Config::GFX_SSAA, true);
+      break;
+    case 5:  // 4x SSAA
+      Config::SetBase(Config::GFX_MSAA, 4);
+      Config::SetBase(Config::GFX_SSAA, true);
+      break;
+    case 6:  // 8x SSAA
+      Config::SetBase(Config::GFX_MSAA, 8);
+      Config::SetBase(Config::GFX_SSAA, true);
+      break;
+    default: // disabled
+      Config::SetBase(Config::GFX_MSAA, 1);
+      Config::SetBase(Config::GFX_SSAA, false);
+      break;
+  }
+
   Libretro::Video::Init();
   VideoBackendBase::PopulateBackendInfo();
   NOTICE_LOG(VIDEO, "Using GFX backend: %s", Config::Get(Config::MAIN_GFX_BACKEND).c_str());

--- a/Source/Core/DolphinLibretro/Options.cpp
+++ b/Source/Core/DolphinLibretro/Options.cpp
@@ -131,6 +131,8 @@ Option<ShaderCompilationMode> shaderCompilationMode(
 Option<bool> waitForShaders("dolphin_wait_for_shaders", "Wait for Shaders before Starting", false);
 Option<bool> progressiveScan("dolphin_progressive_scan", "Progressive Scan", true);
 Option<bool> pal60("dolphin_pal60", "PAL60", true);
+Option<int> antiAliasing("dolphin_anti_aliasing", "Anti-Aliasing",
+    {"None", "2x MSAA", "4x MSAA", "8x MSAA", "2x SSAA", "4x SSAA", "8x SSAA"});
 Option<int> maxAnisotropy("dolphin_max_anisotropy", "Max Anisotropy", {"1x", "2x", "4x", "8x", "16x"});
 Option<bool> skipDupeFrames("dolphin_skip_dupe_frames", "Skip Presenting Duplicate Frames", true);
 Option<bool> immediatexfb("dolphin_immediate_xfb", "Immediate XFB", false);

--- a/Source/Core/DolphinLibretro/Options.h
+++ b/Source/Core/DolphinLibretro/Options.h
@@ -97,6 +97,7 @@ extern Option<ShaderCompilationMode> shaderCompilationMode;
 extern Option<bool> waitForShaders;
 extern Option<bool> progressiveScan;
 extern Option<bool> pal60;
+extern Option<int> antiAliasing;
 extern Option<int> maxAnisotropy;
 extern Option<bool> skipDupeFrames;
 extern Option<bool> immediatexfb;


### PR DESCRIPTION
Zoom 300%, screenshots taken at 1280x1056 (x2 internal res):

None | ![image](https://user-images.githubusercontent.com/33353403/205111069-b9d6396e-1d1c-421d-83a9-c0c263ee23e0.png)
:-:|:-:
2x MSAA | ![image](https://user-images.githubusercontent.com/33353403/205111113-afbd8b6e-05ef-4cad-9690-616469f8be50.png)
4x MSAA | ![image](https://user-images.githubusercontent.com/33353403/205111227-d4ba6bce-9f06-4b21-b045-0e75f7050bb6.png)
8x MSAA | ![image](https://user-images.githubusercontent.com/33353403/205111265-d99aba55-7d49-4617-8f6c-b238d8efcbf3.png)

SSAA looks better but it's not always super noticeable (and it's much more demanding):

8x MSAA | 8x SSAA
:-:|:-:
![image](https://user-images.githubusercontent.com/33353403/205114529-cee4cf06-7aaf-4855-801e-12cdb3343e10.png) | ![image](https://user-images.githubusercontent.com/33353403/205114574-53eb703b-55eb-4116-a672-42e0d883bf61.png)
![image](https://user-images.githubusercontent.com/33353403/205118227-ab39c647-c4c7-4809-a1bd-38c5a9cf7a45.png) | ![image](https://user-images.githubusercontent.com/33353403/205118280-90ab4a2c-107f-46ca-b2b1-a123ff930ced.png)

Click to enlarge the screenshots then check the character shadow on the Killer7 screens and the edges on the "wanted" poster on the Mario Sunshine screens, much smoother with SSAA. Only tried these 2 games, maybe it's way noticeable on other games, idk.

Closes #292