### PR TITLE
Expose the "Speed Up Disc Transfer Rate" option

### DIFF
--- a/Source/Core/DolphinLibretro/Boot.cpp
+++ b/Source/Core/DolphinLibretro/Boot.cpp
@@ -107,6 +107,7 @@ bool retro_load_game(const struct retro_game_info* game)
   SConfig::GetInstance().m_WiimoteContinuousScanning = Libretro::Options::WiimoteContinuousScanning;
   SConfig::GetInstance().bEnableCheats = Libretro::Options::cheatsEnabled;
   SConfig::GetInstance().bOnScreenDisplayMessages = Libretro::Options::osdEnabled;
+  SConfig::GetInstance().bFastDiscSpeed = Libretro::Options::fastDiscSpeed;
 
   Config::SetBase(Config::SYSCONF_LANGUAGE, (u32)(DiscIO::Language)Libretro::Options::Language);
   Config::SetBase(Config::SYSCONF_WIDESCREEN, Libretro::Options::Widescreen);

--- a/Source/Core/DolphinLibretro/Options.cpp
+++ b/Source/Core/DolphinLibretro/Options.cpp
@@ -176,6 +176,7 @@ Option<float> EmulationSpeed("dolphin_emulation_speed", "Emulation Speed",
                            {{"unlimited", 0.0},
                             {"100%", 1.0}});
 Option<bool> fastmem("dolphin_fastmem", "Fastmem", true);
+Option<bool> fastDiscSpeed("dolphin_fast_disc_speed", "Speed Up Disc Transfer Rate", false);
 Option<int> irMode("dolphin_ir_mode", "Wiimote IR Mode", 1,
     {"Right Stick controls pointer (relative)",
      "Right Stick controls pointer (absolute)",

--- a/Source/Core/DolphinLibretro/Options.h
+++ b/Source/Core/DolphinLibretro/Options.h
@@ -115,6 +115,7 @@ extern Option<PowerPC::CPUCore> cpu_core;
 extern Option<float> cpuClockRate;
 extern Option<float> EmulationSpeed;
 extern Option<bool> fastmem;
+extern Option<bool> fastDiscSpeed;
 extern Option<int> irMode;
 extern Option<int> irCenter;
 extern Option<int> irWidth;


### PR DESCRIPTION
Disabled by default as it probably breaks some games, OFF/ON comparison in Chibi-Robo as an example:

https://user-images.githubusercontent.com/33353403/205920292-03e65f69-93b2-4d05-89bb-d93cb0ca9d6e.mp4

Closes #294