### PR TITLE
Fix refresh rate for PAL GC games with 60Hz option

### DIFF
--- a/Source/Core/DolphinLibretro/Main.cpp
+++ b/Source/Core/DolphinLibretro/Main.cpp
@@ -295,11 +295,7 @@ bool retro_unserialize(const void* data, size_t size)
 
 unsigned retro_get_region(void)
 {
-  if (DiscIO::IsNTSC(SConfig::GetInstance().m_region) ||
-      (SConfig::GetInstance().bWii && Config::Get(Config::SYSCONF_PAL60)))
-    return RETRO_REGION_NTSC;
-
-  return RETRO_REGION_PAL;
+  return RETRO_REGION_NTSC;
 }
 
 unsigned retro_api_version()

--- a/Source/Core/DolphinLibretro/Options.cpp
+++ b/Source/Core/DolphinLibretro/Options.cpp
@@ -130,7 +130,7 @@ Option<ShaderCompilationMode> shaderCompilationMode(
      {"a-sync UberShaders", ShaderCompilationMode::AsynchronousUberShaders}});
 Option<bool> waitForShaders("dolphin_wait_for_shaders", "Wait for Shaders before Starting", false);
 Option<bool> progressiveScan("dolphin_progressive_scan", "Progressive Scan", true);
-Option<bool> pal60("dolphin_pal60", "PAL60", true);
+Option<bool> pal60("dolphin_pal60", "PAL60 (Wii)", true);
 Option<int> antiAliasing("dolphin_anti_aliasing", "Anti-Aliasing",
     {"None", "2x MSAA", "4x MSAA", "8x MSAA", "2x SSAA", "4x SSAA", "8x SSAA"});
 Option<int> maxAnisotropy("dolphin_max_anisotropy", "Max Anisotropy", {"1x", "2x", "4x", "8x", "16x"});


### PR DESCRIPTION
Tested with Super Mario Sunshine, currently with the PAL version if you select "60Hz" in-game the core will still lock refresh rate to 50, making the audio awful and the game still running at 50 (25 internally).

I wasn't sure how to handle this so I just checked at how LRPS2 was handling this and it just reports NTSC timing no matter what in `retro_get_system_av_info`, and it seems to work absolutely fine with Dolphin as well. I tried multiple PAL GC and Wii games just to make sure, switching between 50 and 60Hz, I couldn't find any problem, the core properly runs at the correct refresh rate.

Also changed `PAL60` core option name to `PAL60 (Wii)` to avoid confusion, since this setting only affects Wii games.

Fixes #310