### PR TITLE
Fix build on some systems

### DIFF
--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -4,6 +4,7 @@
 
 #include "Core/Debugger/PPCDebugInterface.h"
 
+#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <string>


### PR DESCRIPTION
The complaint was: error: ‘reverse’ is not a member of ‘std’