### PR TITLE
GameSettings: Set SyncGPU to True in GWRE01.ini.

### DIFF
--- a/Data/Sys/GameSettings/GWR.ini
+++ b/Data/Sys/GameSettings/GWR.ini
@@ -1,0 +1,7 @@
+# GWRE01, GWRJ01, GWRP01 - WAVE RACE / BLUE STORM
+
+[Core]
+# Disable multi-threading to avoid a hang in the game menu.
+# TODO: Change to 'CPUThread = False' after rebasing to latest
+# upstream (see commit 869edd5a66).
+SyncGPU = True


### PR DESCRIPTION
As mentioned in
https://wiki.dolphin-emu.org/index.php?title=Wave_Race:_Blue_Storm, the menu may freeze otherwise.

* Data/Sys/GameSettings/GWRE01.ini [Core]: Add SyncGPU = True option.