### PR TITLE
add missing include to fix build with gcc14

### DIFF
--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -4,6 +4,7 @@
 
 #include "Core/Debugger/PPCDebugInterface.h"
 
+#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <string>


### PR DESCRIPTION
without this header file compiler complains about reverse not being a member of std.