### PR TITLE
Fix GC language

### DIFF
--- a/Source/Core/DolphinLibretro/Boot.cpp
+++ b/Source/Core/DolphinLibretro/Boot.cpp
@@ -138,8 +138,9 @@ bool retro_load_game(const struct retro_game_info* game)
   Config::SetCurrent(Config::MAIN_ENABLE_CHEATS,
                      Libretro::GetOption<bool>(core::CHEATS_ENABLED, /*def=*/false));
 
-  Config::SetCurrent(Config::MAIN_GC_LANGUAGE,
-                     Libretro::GetOption<int>(core::LANGUAGE, static_cast<int>(DiscIO::Language::English)));
+  const int language = Libretro::GetOption<int>(core::LANGUAGE, static_cast<int>(DiscIO::Language::English));
+  Config::SetCurrent(Config::SYSCONF_LANGUAGE, language);
+  Config::SetCurrent(Config::MAIN_GC_LANGUAGE, DiscIO::ToGameCubeLanguage(static_cast<DiscIO::Language>(language)));
 
   Config::SetCurrent(Config::MAIN_DPL2_DECODER, false);
   Config::SetCurrent(Config::MAIN_AUDIO_LATENCY, 0);

--- a/Source/Core/DolphinLibretro/Common/Options.cpp
+++ b/Source/Core/DolphinLibretro/Common/Options.cpp
@@ -237,7 +237,7 @@ static struct retro_core_option_v2_definition option_defs[] = {
       { "1", "English" }, // DiscIO::Language::English
       { "0", "Japanese" }, // DiscIO::Language::Japanese
       { "2", "German" }, // DiscIO::Language::German
-      { "3" "French" }, // DiscIO::Language::French
+      { "3", "French" }, // DiscIO::Language::French
       { "4", "Spanish" }, // DiscIO::Language::Spanish
       { "5", "Italian" }, // DiscIO::Language::Italian
       { "6", "Dutch" }, // DiscIO::Language::Dutch


### PR DESCRIPTION
Saw https://www.reddit.com/r/RetroArch/comments/1om0smf/language_issues_in_gamecube_games/
and I can reproduce, tested with Animal Crossing on GC and it boots in German while core option is set to English.