### PR TITLE
Add a GC core option for BIOS

### DIFF
--- a/Source/Core/DolphinLibretro/Boot.cpp
+++ b/Source/Core/DolphinLibretro/Boot.cpp
@@ -138,6 +138,8 @@ bool retro_load_game(const struct retro_game_info* game)
   Config::SetCurrent(Config::MAIN_ENABLE_CHEATS,
                      Libretro::GetOption<bool>(core::CHEATS_ENABLED, /*def=*/false));
 
+  Config::SetCurrent(Config::MAIN_SKIP_IPL, Libretro::GetOption<bool>(core::SKIP_GC_BIOS, /*def=*/true));
+
   const int language = Libretro::GetOption<int>(core::LANGUAGE, static_cast<int>(DiscIO::Language::English));
   Config::SetCurrent(Config::SYSCONF_LANGUAGE, language);
   Config::SetCurrent(Config::MAIN_GC_LANGUAGE, DiscIO::ToGameCubeLanguage(static_cast<DiscIO::Language>(language)));

--- a/Source/Core/DolphinLibretro/Common/Options.cpp
+++ b/Source/Core/DolphinLibretro/Common/Options.cpp
@@ -227,6 +227,20 @@ static struct retro_core_option_v2_definition option_defs[] = {
     "disabled"
   },
   {
+    Libretro::Options::core::SKIP_GC_BIOS,
+    "Skip GameCube BIOS",
+    nullptr,
+    "Skip the GameCube BIOS animation/menu and start the game directly.",
+    nullptr,
+    CATEGORY_CORE,
+    {
+      { "disabled", nullptr },
+      { "enabled",  nullptr },
+      { nullptr, nullptr }
+    },
+    "enabled"
+  },
+  {
     Libretro::Options::core::LANGUAGE,
     "System Language",
     nullptr,

--- a/Source/Core/DolphinLibretro/Common/Options.h
+++ b/Source/Core/DolphinLibretro/Common/Options.h
@@ -123,6 +123,7 @@ namespace core {
   constexpr const char FASTMEM[] = "dolphin_fastmem";
   constexpr const char FASTMEM_ARENA[] = "dolphin_fastmem_arena";
   constexpr const char CHEATS_ENABLED[] = "dolphin_cheats_enabled";
+  constexpr const char SKIP_GC_BIOS[] = "dolphin_skip_gc_bios";
   constexpr const char LANGUAGE[] = "dolphin_language";
   constexpr const char FAST_DISC_SPEED[] = "dolphin_fast_disc_speed";
   constexpr const char MAIN_MMU[] = "dolphin_main_mmu";


### PR DESCRIPTION
This PR adds an option to skip the GC BIOS or not. Filename must be `IPL.bin` and be placed in either `<system_dir>/dolphin-emu/Sys/GC/<region>/` or `<save_dir>/User/GC/<region>/`. Automatically skipped if the file isn't found or the returned region is unknown.

Added the file check inside `BootManager.cpp` because disc region isn't available before and we have to set `MAIN_SKIP_IPL` to true before `Core::Init()` if the file is missing or RetroArch will hang (standalone shows a popup error and closes the game).

Closes #89
Closes #127
Closes #224