### PR TITLE
Second patch using CRLF

### DIFF
--- a/Externals/cpp-ipc/CMakeLists.txt
+++ b/Externals/cpp-ipc/CMakeLists.txt
@@ -12,6 +12,11 @@ if (MINGW)
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/Externals/cpp-ipc/cpp-ipc
     RESULT_VARIABLE PATCH_RESULT
   )
+  execute_process(
+    COMMAND patch --forward -p1 -i ${CMAKE_SOURCE_DIR}/Externals/cpp-ipc/patches/0002-windows-h-mingw-extra.patch
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/Externals/cpp-ipc/cpp-ipc
+    RESULT_VARIABLE PATCH_RESULT
+  )
 endif()
 
 add_library(cpp-ipc::ipc ALIAS ipc)

--- a/Externals/cpp-ipc/patches/0001-windows-h-mingw.patch
+++ b/Externals/cpp-ipc/patches/0001-windows-h-mingw.patch
@@ -37,26 +37,3 @@ index 6cf94de..252d78e 100644
  
  #include "libipc/utility/log.h"
  
-diff --git a/src/libipc/platform/win/shm_win.cpp b/src/libipc/platform/win/shm_win.cpp
-index b19245f..dd70abe 100755
---- a/src/libipc/platform/win/shm_win.cpp
-+++ b/src/libipc/platform/win/shm_win.cpp
-@@ -1,5 +1,5 @@
- 
--#include <Windows.h>
-+#include <windows.h>
- 
- #include <string>
- #include <utility>
-diff --git a/src/libipc/platform/win/to_tchar.h b/src/libipc/platform/win/to_tchar.h
-index 94bc83e..d344fbd 100755
---- a/src/libipc/platform/win/to_tchar.h
-+++ b/src/libipc/platform/win/to_tchar.h
-@@ -1,6 +1,6 @@
- #pragma once
- 
--#include <Windows.h>
-+#include <windows.h>
- 
- #include <type_traits>
- #include <string>

--- a/Externals/cpp-ipc/patches/0002-windows-h-mingw-extra.patch
+++ b/Externals/cpp-ipc/patches/0002-windows-h-mingw-extra.patch
@@ -1,0 +1,23 @@
+diff --git a/src/libipc/platform/win/shm_win.cpp b/src/libipc/platform/win/shm_win.cpp
+index b19245f..dd70abe 100755
+--- a/src/libipc/platform/win/shm_win.cpp
++++ b/src/libipc/platform/win/shm_win.cpp
+@@ -1,5 +1,5 @@
+ 
+-#include <Windows.h>
++#include <windows.h>
+ 
+ #include <string>
+ #include <utility>
+diff --git a/src/libipc/platform/win/to_tchar.h b/src/libipc/platform/win/to_tchar.h
+index 94bc83e..d344fbd 100755
+--- a/src/libipc/platform/win/to_tchar.h
++++ b/src/libipc/platform/win/to_tchar.h
+@@ -1,6 +1,6 @@
+ #pragma once
+ 
+-#include <Windows.h>
++#include <windows.h>
+ 
+ #include <type_traits>
+ #include <string>


### PR DESCRIPTION
src/libipc/platform/win/shm_win.cpp
src/libipc/platform/win/to_tchar.h

have CRLF line endings.!