### PR TITLE
Small core options cleanup

### DIFF
--- a/Source/Core/DolphinLibretro/Common/Options.cpp
+++ b/Source/Core/DolphinLibretro/Common/Options.cpp
@@ -227,8 +227,8 @@ static struct retro_core_option_v2_definition option_defs[] = {
   },
   {
     Libretro::Options::core::SKIP_GC_BIOS,
+    "Core > Skip GameCube BIOS",
     "Skip GameCube BIOS",
-    nullptr,
     "Skip the GameCube BIOS animation/menu and start the game directly.",
     nullptr,
     CATEGORY_CORE,
@@ -331,22 +331,6 @@ static struct retro_core_option_v2_definition option_defs[] = {
     "Enable the debugger.",
     nullptr,
     CATEGORY_INTERFACE,
-    {
-      { "disabled", nullptr },
-      { "enabled",  nullptr },
-      { nullptr, nullptr }
-    },
-    "disabled"
-  },
-
-  // Main.BluetoothPassthrough
-  {
-    Libretro::Options::main_bluetooth::BLUETOOTH_PASSTHROUGH,
-    "Bluetooth passthrough mode",
-    nullptr,
-    "Pass all traffic directly to the host’s Bluetooth adapter. This might CRASH if your adaptor is not compatible.",
-    nullptr,
-    CATEGORY_SYSCONF,
     {
       { "disabled", nullptr },
       { "enabled",  nullptr },
@@ -505,6 +489,22 @@ static struct retro_core_option_v2_definition option_defs[] = {
     "System Configuration > Alt GC Ports (Wii)",
     "Alt GC Ports (Wii)",
     "Use ports 5-8 for GameCube controllers in Wii mode.",
+    nullptr,
+    CATEGORY_SYSCONF,
+    {
+      { "disabled", nullptr },
+      { "enabled",  nullptr },
+      { nullptr, nullptr }
+    },
+    "disabled"
+  },
+
+  // Main.BluetoothPassthrough
+  {
+    Libretro::Options::main_bluetooth::BLUETOOTH_PASSTHROUGH,
+    "System Configuration > Bluetooth passthrough mode",
+    "Bluetooth passthrough mode",
+    "Pass all traffic directly to the host's Bluetooth adapter. This might CRASH if your adaptor is not compatible.",
     nullptr,
     CATEGORY_SYSCONF,
     {

--- a/Source/Core/DolphinLibretro/Input.cpp
+++ b/Source/Core/DolphinLibretro/Input.cpp
@@ -887,7 +887,7 @@ void retro_set_controller_port_device_wii(unsigned port, unsigned device)
       wmButtons->SetControlExpression(4, "L");                             // -
       wmButtons->SetControlExpression(5, "R");                             // +
 
-      if (irMode != 1 && irMode != 2)
+      if (irMode != 0 && irMode != 1)
       {
         wmTilt->SetControlExpression(0, "`" + devAnalog + ":Y1-`");  // Forward
         wmTilt->SetControlExpression(1, "`" + devAnalog + ":Y1+`");  // Backward
@@ -925,7 +925,7 @@ void retro_set_controller_port_device_wii(unsigned port, unsigned device)
     wmDPad->SetControlExpression(2, "Left");   // Left
     wmDPad->SetControlExpression(3, "Right");  // Right
 
-    if (irMode == 1 || irMode == 2)
+    if (irMode == 0 || irMode == 1)
     {
       // Set right stick to control the IR
       wmIR->SetControlExpression(0, "`" + devAnalog + ":Y1-`");     // Up
@@ -933,7 +933,7 @@ void retro_set_controller_port_device_wii(unsigned port, unsigned device)
       wmIR->SetControlExpression(2, "`" + devAnalog + ":X1-`");     // Left
       wmIR->SetControlExpression(3, "`" + devAnalog + ":X1+`");     // Right
       static_cast<ControllerEmu::NumericSetting<bool>*>(wmIR->numeric_settings[4].get())
-        ->SetValue(irMode == 1);                 // Relative input
+        ->SetValue(irMode == 0);                                    // Relative input
       static_cast<ControllerEmu::NumericSetting<bool>*>(wmIR->numeric_settings[5].get())
         ->SetValue(true);                                           // Auto hide
     }


### PR DESCRIPTION
* Added prefix to the uncategorized name of the new options.
* Moved "Bluetooth passthrough" so it's grouped with the other "System Configuration" options when categories are disabled.
* IR mode values were shifted in Options.cpp during the switch to core options V2 (1, 2, 3 -> 0, 1, 2), adjusted in Input.cpp as it makes more sense + it won't shift current values for the users.