### PR TITLE
Fix achievements on Windows

### DIFF
--- a/Source/Core/Common/DirectIOFile.cpp
+++ b/Source/Core/Common/DirectIOFile.cpp
@@ -89,6 +89,13 @@ bool DirectIOFile::Open(const std::string& path, AccessMode access_mode, OpenMod
   // Allow deleting and renaming through our handle.
   desired_access |= DELETE;
 
+#ifdef __LIBRETRO__
+  // The DELETE flag prevents the Libretro implementation of RetroAchievements from
+  // opening the file so make sure only GENERIC_READ is set when we're in read mode.
+  if (access_mode == AccessMode::Read)
+    desired_access = GENERIC_READ;
+#endif
+
   // All sharing is allowed to more closely match default behavior on other OSes.
   constexpr DWORD share_mode = FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE;
 


### PR DESCRIPTION
Currently achievements don't work on Windows because it can't open the file to calculate the hash, this is because of the `DELETE` flag that is forced even on read mode, so I simply added a small #ifdef (to keep changes as minimal as possible) that will ONLY set the `GENERIC_READ` flag when opening a file in read mode.

I hope this is fine? Made some tests (creating, renaming, removing and deleting a test file) and it doesn't seem to break anything, but wouldn't be against a second opinion :p 

Tested with both ISO and RVZ, haven't actually try to unlock any achievements but they're loading, before:
```
[INFO] [RCHEEVOS] Identifying game: F:\Emulation\Games\Nintendo - GameCube\F-Zero GX (USA).rvz
[INFO] [RCHEEVOS] Found 1 potential consoles for rvz file extension
[INFO] [RCHEEVOS] Trying console 4
[INFO] [RCHEEVOS] Could not open file
[INFO] [RCHEEVOS] Load failed (-25): hash generation failed
[INFO] [RCHEEVOS] Game load failed: hash generation failed
```
after:
```
[INFO] [RCHEEVOS] Identifying game: F:\Emulation\Games\Nintendo - GameCube\F-Zero GX (USA).rvz
[INFO] [RCHEEVOS] Opened F-Zero GX (USA).rvz
[INFO] [RCHEEVOS] Hashing 125764 byte partition header
[INFO] [RCHEEVOS] Hashing 9440 byte main.dol code segment 0
[INFO] [RCHEEVOS] Hashing 567584 byte main.dol code segment 1
[INFO] [RCHEEVOS] Hashing 32 byte main.dol data segment 0
[INFO] [RCHEEVOS] Hashing 32 byte main.dol data segment 1
[INFO] [RCHEEVOS] Hashing 24416 byte main.dol data segment 2
[INFO] [RCHEEVOS] Hashing 809600 byte main.dol data segment 3
[INFO] [RCHEEVOS] Hashing 736 byte main.dol data segment 4
[INFO] [RCHEEVOS] Hashing 2752 byte main.dol data segment 5
[INFO] [RCHEEVOS] Generated hash 15449523ead65939970e336a91bf943b
[...]
[INFO] [RCHEEVOS] Identified game: 9699 "F-Zero GX" (15449523ead65939970e336a91bf943b)
[INFO] [RCHEEVOS] Starting session for game 9699
[INFO] [RCHEEVOS] Registered 0x1800000 bytes of SYSTEM RAM at $000000 (offset 0x000000)
[INFO] [RCHEEVOS] 1/1 memory addresses valid
[INFO] [RCHEEVOS] Game 9699 loaded, hardcore enabled
[INFO] [RCHEEVOS] You have 0 of 229 achievements unlocked
```