### PR TITLE
Add Crop Overscan option for proper NTSC 480i/p CRT output

### DIFF
--- a/Source/Core/DolphinLibretro/Common/Options.cpp
+++ b/Source/Core/DolphinLibretro/Common/Options.cpp
@@ -564,6 +564,20 @@ static struct retro_core_option_v2_definition option_defs[] = {
     "disabled"
   },
   {
+    Libretro::Options::gfx_settings::CROP_OVERSCAN,
+    "Graphics > Settings > Crop Overscan",
+    "Crop Overscan",
+    "Crop overscan to match standard NTSC output resolutions. Recommended for NTSC CRTs.",
+    nullptr,
+    CATEGORY_GFX_SETTINGS,
+    {
+      { "disabled", nullptr },
+      { "enabled",  nullptr },
+      { nullptr, nullptr }
+    },
+    "disabled"
+  },
+  {
     Libretro::Options::gfx_settings::EFB_SCALE,
     "Graphics > Settings > Internal Resolution",
     "Internal Resolution",

--- a/Source/Core/DolphinLibretro/Common/Options.h
+++ b/Source/Core/DolphinLibretro/Common/Options.h
@@ -182,6 +182,7 @@ namespace gfx_hardware {
 namespace gfx_settings {
   constexpr const char RENDERER[] = "dolphin_renderer";
   constexpr const char WIDESCREEN_HACK[] = "dolphin_widescreen_hack";
+  constexpr const char CROP_OVERSCAN[] = "dolphin_crop_overscan";
   constexpr const char EFB_SCALE[] = "dolphin_efb_scale";
   constexpr const char SHADER_COMPILATION_MODE[] = "dolphin_shader_compilation_mode";
   constexpr const char WAIT_FOR_SHADERS[] = "dolphin_wait_for_shaders";

--- a/Source/Core/DolphinLibretro/Main.cpp
+++ b/Source/Core/DolphinLibretro/Main.cpp
@@ -102,8 +102,15 @@ void retro_get_system_av_info(retro_system_av_info* info)
   int efbScale = Libretro::Options::GetCached<int>(
     Libretro::Options::gfx_settings::EFB_SCALE);
 
+  int base_height = EFB_HEIGHT;
+  const bool crop_overscan = Libretro::Options::GetCached<bool>(
+    Libretro::Options::gfx_settings::CROP_OVERSCAN);
+
+  if (crop_overscan && retro_get_region() == RETRO_REGION_NTSC)
+    base_height = 480;
+
   info->geometry.base_width  = EFB_WIDTH * efbScale;
-  info->geometry.base_height = EFB_HEIGHT * efbScale;
+  info->geometry.base_height = base_height * efbScale;
 
   info->geometry.max_width   = info->geometry.base_width;
   info->geometry.max_height  = info->geometry.base_height;
@@ -141,6 +148,14 @@ void retro_run(void)
   Config::SetCurrent(Config::MAIN_OVERCLOCK_ENABLE, cpuClock != 1.0);
   g_Config.bWidescreenHack = Libretro::Options::GetCached<bool>(
     Libretro::Options::gfx_settings::WIDESCREEN_HACK);
+
+  const bool crop_overscan = Libretro::Options::GetCached<bool>(
+    Libretro::Options::gfx_settings::CROP_OVERSCAN);
+
+  if (crop_overscan && retro_get_region() == RETRO_REGION_NTSC)
+    g_Config.bCrop = true;
+  else
+    g_Config.bCrop = false;
 
   Libretro::Input::Update();
 

--- a/Source/Core/DolphinLibretro/Video.cpp
+++ b/Source/Core/DolphinLibretro/Video.cpp
@@ -65,6 +65,17 @@ static Common::DynamicLibrary d3d11_library;
 static Common::DynamicLibrary d3d12_library;
 #endif
 
+static int GetAdjustedBaseHeight()
+{
+  const bool crop_overscan = Libretro::Options::GetCached<bool>(
+    Libretro::Options::gfx_settings::CROP_OVERSCAN);
+
+  if (crop_overscan && retro_get_region() == RETRO_REGION_NTSC)
+    return 480;
+
+  return EFB_HEIGHT;
+}
+
 void Init()
 {
   DEBUG_LOG_FMT(VIDEO, "Video - Init");
@@ -239,7 +250,7 @@ void ContextReset(void)
     int efbScale = Libretro::Options::GetCached<int>(
       Libretro::Options::gfx_settings::EFB_SCALE, 1);
     Vk::SetSurfaceSize(EFB_WIDTH * efbScale,
-                       EFB_HEIGHT * efbScale);
+                       GetAdjustedBaseHeight() * efbScale);
   }
 #endif
 
@@ -296,7 +307,7 @@ void ContextReset(void)
     UpdateActiveConfig();
 
     std::unique_ptr<DX11SwapChain> swap_chain = std::make_unique<DX11SwapChain>(
-      wsi, EFB_WIDTH * efbScale, EFB_HEIGHT * efbScale,
+      wsi, EFB_WIDTH * efbScale, GetAdjustedBaseHeight() * efbScale,
       nullptr, nullptr);
 
     auto gfx = std::make_unique<DX11::Gfx>(std::move(swap_chain), wsi.render_surface_scale);
@@ -373,7 +384,7 @@ void ContextReset(void)
     UpdateActiveConfig();
 
     auto swap_chain = std::make_unique<DX12SwapChain>(
-        wsi, EFB_WIDTH * efbScale, EFB_HEIGHT * efbScale, d3d12);
+        wsi, EFB_WIDTH * efbScale, GetAdjustedBaseHeight() * efbScale, d3d12);
 
     if (!swap_chain->Initialize())
     {


### PR DESCRIPTION
This PR Adds a new core option to fix NTSC video output for CRT displays by cropping the 528-line EFB to standard 480i/p resolution. 

I'm not 100% set on the option name as this could also be used on LCD displays for those that want to throw away the junk pixels

**Problem**
GameCube/Wii uses a 640x528 framebuffer internally, but NTSC video output is 640x480. 

When the core reports 528 lines to frontends a few problems arise.
- CRTSwitchres calculates and creates incorrect video timings, causing ~55Hz output instead of correct ~60Hz
- Audio stuttering since the game is running too slow to sync
- Not true to the original output seen on NGC/Wii with CRT Displays

**Solution**
New core option: Graphics > Settings > Crop Overscan (default: disabled)

When enabled for NTSC games:
- Reports 640x480 geometry to frontend (ensures correct 60Hz timing)
- Forces g_Config.bCrop = true (crops EFB internally, prevents squishing)
- Updates video backend surface/swapchain creation to match
- PAL games are unaffected - all changes are NTSC-conditional.
- Supports scaled internal resolutions (2x = 960p, 3x = 1440p etc)
- Uses Dolphin's existing crop mechanism for proper aspect ratio

**Testing**

- NTSC: Verify 640x480@60Hz output, no vertical squishing
- PAL: untested unchanged behavior (528/576 lines @50Hz)
- Scaled: verified 2x/3x multiplies 480, not 528
