### PR TITLE
libretro: add ubuntu, macOS, windows, android builders to test compilation

### DIFF
--- a/.github/workflows/build-android-libretro.yml
+++ b/.github/workflows/build-android-libretro.yml
@@ -1,0 +1,40 @@
+name: Build Dolphin (libretro) on Android
+
+on: [push, pull_request]
+
+env:
+  core_id: dolphin_libretro
+
+jobs:
+  build-android:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y openjdk-17-jdk wget unzip cmake ninja-build
+        wget https://dl.google.com/android/repository/android-ndk-r26d-linux.zip
+        unzip -q android-ndk-r26d-linux.zip
+        echo "ANDROID_NDK_HOME=$PWD/android-ndk-r26d" >> $GITHUB_ENV
+
+    - name: Checkout Dolphin (libretro) repo
+      uses: actions/checkout@v6
+      with:
+        path: ${{ env.core_id }}
+        submodules: recursive
+
+    - name: Configure
+      run: |
+        cd ${{ env.core_id }}
+        cmake -B build/android-arm64-v8a \
+          -DLIBRETRO=ON \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DANDROID_ABI=arm64-v8a \
+          -DANDROID_PLATFORM=android-26 \
+          -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake \
+          -G Ninja
+
+    - name: Build
+      run: |
+        cd ${{ env.core_id }}/build/android-arm64-v8a
+        ninja -j$(nproc)

--- a/.github/workflows/build-iOS-libretro.yml
+++ b/.github/workflows/build-iOS-libretro.yml
@@ -1,0 +1,42 @@
+name: Build Dolphin (libretro) on iOS
+
+on: [push, pull_request]
+
+env:
+  core_id: dolphin_libretro
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+    - name: Install dependencies
+      run: |
+        brew update
+        brew install cmake mbedtls zlib
+
+    - name: Checkout Dolphin (libretro) repo
+      uses: actions/checkout@v6
+      with:
+        path: ${{ env.core_id }}
+        submodules: recursive
+
+    - name: Configure (iOS arm64)
+      run: |
+        cd ${{ env.core_id }}
+        cmake \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+          -DCMAKE_C_FLAGS="" \
+          -DCMAKE_CXX_FLAGS="" \
+          -DIOS=ON \
+          -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 \
+          -DCMAKE_SYSTEM_NAME=iOS \
+          -DCMAKE_SYSTEM_PROCESSOR=arm64 \
+          -DCMAKE_OSX_ARCHITECTURES=arm64 \
+          -DLIBRETRO=ON \
+          . -Bbuild/ios-arm64
+
+    - name: Build
+      run: |
+        cd ${{ env.core_id }}/build/ios-arm64
+        make -j$(sysctl -n hw.ncpu)

--- a/.github/workflows/build-macOS-libretro.yml
+++ b/.github/workflows/build-macOS-libretro.yml
@@ -1,0 +1,43 @@
+name: Build Dolphin (libretro) on macOS
+
+on: [push, pull_request]
+
+env:
+  core_id: dolphin_libretro
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - name: "macOS x64"
+          os: macos-latest
+          ZIP_NAME_SUFFIX: macos_x64
+    steps:
+    - name: Install dependencies
+      run: |
+        brew update
+        brew install cmake \
+          mbedtls zlib
+
+    - name: Checkout Dolphin (libretro) repo
+      uses: actions/checkout@v6
+      with:
+        path: ${{ env.core_id }}
+        submodules: recursive
+
+    - name: Configure
+      run: |
+        cd ${{ env.core_id }}
+        mkdir -p build && cd build
+        cmake .. \
+          -DLIBRETRO=ON \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install
+
+    - name: Build
+      run: |
+        cd ${{ env.core_id }}/build
+        make -j$(sysctl -n hw.ncpu)

--- a/.github/workflows/build-ubuntu-libretro.yml
+++ b/.github/workflows/build-ubuntu-libretro.yml
@@ -1,0 +1,46 @@
+name: Build Dolphin (libretro) on Ubuntu x64
+
+on: [push, pull_request]
+
+env:
+  core_id: dolphin_libretro
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - name: "Ubuntu x64"
+          os: ubuntu-latest
+          ZIP_NAME_SUFFIX: linux_x64
+    steps:
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y cmake ninja-build pkg-config \
+          libasound2-dev \
+          libx11-dev libxi-dev libxrandr-dev libudev-dev libevdev-dev \
+          libegl1-mesa-dev libgl1-mesa-dev \
+          libmbedtls-dev libcurl4-openssl-dev zlib1g-dev
+
+    - name: Checkout Dolphin (libretro) repo
+      uses: actions/checkout@v6
+      with:
+        path: ${{ env.core_id }}
+        submodules: recursive
+
+    - name: Configure
+      run: |
+        cd ${{ env.core_id }}
+        mkdir -p build && cd build
+        cmake .. \
+          -DLIBRETRO=ON \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install
+
+    - name: Build
+      run: |
+        cd ${{ env.core_id }}/build
+        make -j$(nproc)

--- a/.github/workflows/build-windows-ming-libretro.yml
+++ b/.github/workflows/build-windows-ming-libretro.yml
@@ -1,0 +1,49 @@
+name: Build Dolphin (libretro) for Windows (MinGW on Ubuntu)
+
+on: [push, pull_request]
+
+env:
+  core_id: dolphin_libretro
+
+jobs:
+  build-windows-mingw:
+    runs-on: ubuntu-latest
+    container: ubuntu:25.10
+    steps:
+    - name: Install dependencies
+      run: |
+        apt update
+        apt install -y git cmake ninja-build pkg-config \
+          mingw-w64
+
+    - name: Checkout Dolphin (libretro) repo
+      uses: actions/checkout@v6
+      with:
+        path: ${{ env.core_id }}
+        submodules: recursive
+
+    - name: Configure (MinGW cross-compile)
+      run: |
+        cd ${{ env.core_id }}
+        export PKG_CONFIG_LIBDIR=/usr/x86_64-w64-mingw32/lib/pkgconfig
+        export PKG_CONFIG_PATH=/usr/x86_64-w64-mingw32/share/pkgconfig
+        export PKG_CONFIG_SYSROOT_DIR=/usr/x86_64-w64-mingw32
+        mkdir -p build && cd build
+        cmake .. \
+          -DLIBRETRO=ON \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_SYSTEM_NAME=Windows \
+          -DCMAKE_SYSTEM_PROCESSOR=x86_64 \
+          -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc \
+          -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ \
+          -DCMAKE_RC_COMPILER=x86_64-w64-mingw32-windres \
+          -DCMAKE_FIND_ROOT_PATH=/usr/x86_64-w64-mingw32 \
+          -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=NEVER \
+          -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY \
+          -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY \
+          -G Ninja
+
+    - name: Build
+      run: |
+        cd ${{ env.core_id }}/build
+        ninja -j$(nproc)

--- a/.github/workflows/build-windows-msvc-libretro.yml
+++ b/.github/workflows/build-windows-msvc-libretro.yml
@@ -1,0 +1,29 @@
+name: Build Dolphin (libretro) on Windows (MSVC)
+
+on: [push, pull_request]
+
+env:
+  core_id: dolphin_libretro
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+    - name: Install dependencies
+      run: |
+        choco install cmake ninja git
+    - name: Checkout Dolphin (libretro) repo
+      uses: actions/checkout@v6
+      with:
+        path: ${{ env.core_id }}
+        submodules: recursive
+
+    - name: Configure (MSVC)
+      run: |
+        cd ${{ env.core_id }}
+        mkdir build && cd build
+        cmake .. -DLIBRETRO=ON -DCMAKE_BUILD_TYPE=Release -G "Visual Studio 17 2022" -A x64
+
+    - name: Build
+      run: |
+        cmake --build ${{ env.core_id }}/build --config Release --parallel


### PR DESCRIPTION
Tests future PRs for building on:

- Android
- Linux (Ubuntu)
- Windows (MSVC)
- Windows (mingw)
- MacOS
- iOS

Does not produce any artifacts.