### PR TITLE
libretro: fix bluetooth passthrough mode

### DIFF
--- a/Source/Core/DolphinLibretro/Common/Options.cpp
+++ b/Source/Core/DolphinLibretro/Common/Options.cpp
@@ -519,7 +519,7 @@ static struct retro_core_option_v2_definition option_defs[] = {
     Libretro::Options::main_bluetooth::BLUETOOTH_PASSTHROUGH,
     "System Configuration > Bluetooth passthrough mode",
     "Bluetooth passthrough mode",
-    "Pass all traffic directly to the host's Bluetooth adapter. This might CRASH if your adaptor is not compatible.",
+    "Pass all traffic directly to the host's Bluetooth adapter. Press F12 to begin the sync process.",
     nullptr,
     CATEGORY_SYSCONF,
     {

--- a/Source/Core/DolphinLibretro/Input.cpp
+++ b/Source/Core/DolphinLibretro/Input.cpp
@@ -8,6 +8,7 @@
 #include "Common/IniFile.h"
 #include "Common/Logging/Log.h"
 #include "Core/Config/MainSettings.h"
+#include "Core/Config/WiimoteSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/FreeLookManager.h"
 #include "Core/HW/GBAPad.h"
@@ -21,8 +22,10 @@
 #include "Core/HW/WiimoteReal/WiimoteReal.h"
 #include "Core/HW/SI/SI.h"
 #include "Core/HW/SI/SI_Device.h"
+#include "Core/IOS/USB/Bluetooth/BTReal.h"
 #include "Core/Host.h"
 #include "Core/System.h"
+#include "Core/WiiUtils.h"
 #include "DolphinLibretro/Input.h"
 #include "DolphinLibretro/Common/Options.h"
 #include "InputCommon/ControlReference/ControlReference.h"
@@ -34,10 +37,6 @@
 #include "InputCommon/GCAdapter.h"
 #include "InputCommon/GCPadStatus.h"
 #include "InputCommon/InputConfig.h"
-#include "Core/Config/WiimoteSettings.h"
-
-//#include "UICommon/UICommon.h"
-//#include "Core/HotkeyManager.h"
 
 #define RETRO_DEVICE_WIIMOTE RETRO_DEVICE_JOYPAD
 #define RETRO_DEVICE_WIIMOTE_SW ((2 << 8) | RETRO_DEVICE_JOYPAD)
@@ -579,6 +578,21 @@ void ResetControllers()
 {
   for (int port = 0; port < 4; port++)
     retro_set_controller_port_device(port, input_types[port]);
+}
+
+void BluetoothPassthroughBind()
+{
+  static bool was_pressed = false;
+  bool sync = Libretro::Input::input_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_F12);
+
+  if (sync && !was_pressed)
+  {
+    auto bt_real = WiiUtils::GetBluetoothRealDevice();
+    if (bt_real)
+      bt_real->TriggerSyncButtonPressedEvent();
+  }
+
+  was_pressed = sync;
 }
 
 }  // namespace Input

--- a/Source/Core/DolphinLibretro/Input.h
+++ b/Source/Core/DolphinLibretro/Input.h
@@ -12,5 +12,6 @@ void InitStage2();
 void Update();
 void Shutdown();
 void ResetControllers();
+void BluetoothPassthroughBind();
 }
 }

--- a/Source/Core/DolphinLibretro/Main.cpp
+++ b/Source/Core/DolphinLibretro/Main.cpp
@@ -36,7 +36,6 @@
 #include "VideoCommon/VideoConfig.h"
 #include "VideoCommon/Widescreen.h"
 #include "Core/Boot/Boot.h"
-#include "Core/HW/CPU.h"
 
 #ifdef PERF_TEST
 static struct retro_perf_callback perf_cb;
@@ -244,6 +243,9 @@ void retro_run(void)
       Libretro::Options::GetCached<bool>(Libretro::Options::sysconf::WIIMOTE_CONTINUOUS_SCANNING));
     WiimoteReal::Initialize(Wiimote::InitializeMode::DO_NOT_WAIT_FOR_WIIMOTES);
   }
+
+  if (Config::Get(Config::MAIN_BLUETOOTH_PASSTHROUGH_ENABLED))
+    Libretro::Input::BluetoothPassthroughBind();
 
   RETRO_PERFORMANCE_INIT(dolphin_main_func);
   RETRO_PERFORMANCE_START(dolphin_main_func);


### PR DESCRIPTION
Tested under Linux. 

Note it relies on Auto selection of bluetooth adapter, as per standalone. There is no option to select a specific adapter, this could be improved upon in the future by adding this option.

Follow https://wiki.dolphin-emu.org/index.php?title=Bluetooth_Passthrough#Linux to make sure your device has appropriate access.

To use this, enable the setting, load the game, press F12 to start pairing and sync your remote.

Not needed for dolphin bar (mode 4)