### PR TITLE
libretro: support sensor data for emulated controllers

### DIFF
--- a/Source/Core/DolphinLibretro/Common/Options.cpp
+++ b/Source/Core/DolphinLibretro/Common/Options.cpp
@@ -71,8 +71,8 @@ static const struct retro_core_option_v2_category option_cats[] = {
   },
   {
     CATEGORY_WIIMOTE,
-    "Wiimote IR",
-    "Configure Wiimote infrared pointer settings."
+    "Wiimote IR / Gyro / Swing",
+    "Configure Wiimote infrared pointer, gyro and swing settings."
   },
   { NULL, NULL, NULL }
 };
@@ -1159,6 +1159,32 @@ static struct retro_core_option_v2_definition option_defs[] = {
   },
   #endif
 
+  {
+    Libretro::Options::wiimote::HOTKEY_SIDEWAYS_TOGGLE,
+    "WiiMote Sideways > Toggle Button",
+    "Sideways Toggle Button",
+    "Button used to toggle sideways mode. Can be disabled.",
+    nullptr,
+    CATEGORY_WIIMOTE,
+    {
+      { MODIFIER_DISABLED_CONTROL, "Disabled" },
+      { "L3",     "L3 (Default)" },
+      { "R3",     nullptr },
+      { "L1",     nullptr },
+      { "R1",     nullptr },
+      { "L2",     nullptr },
+      { "R2",     nullptr },
+      { "A",      nullptr },
+      { "B",      nullptr },
+      { "X",      nullptr },
+      { "Y",      nullptr },
+      { "Start",  nullptr },
+      { "Select", nullptr },
+      { nullptr,  nullptr }
+    },
+    "L3"
+  },
+
   // ========== Wiimote IR ==========
   {
     Libretro::Options::wiimote::IR_MODE,
@@ -1279,6 +1305,114 @@ static struct retro_core_option_v2_definition option_defs[] = {
       { nullptr, nullptr }
     },
     "25"
+  },
+  {
+    Libretro::Options::wiimote::IR_DEADZONE,
+    "Wiimote IR > Wiimote IR Deadzone",
+    "IR Deadzone",
+    "Amount of small IR‑cursor movement to ignore (0–50%).",
+    nullptr,
+    CATEGORY_WIIMOTE,
+    {
+      { "0",  "0% (No Deadzone)" },
+      { "1",  nullptr }, { "2",  nullptr }, { "3",  nullptr }, { "4",  nullptr }, { "5",  nullptr },
+      { "6",  nullptr }, { "7",  nullptr }, { "8",  nullptr }, { "9",  nullptr }, { "10", nullptr },
+      { "11", nullptr }, { "12", nullptr }, { "13", nullptr }, { "14", nullptr }, { "15", nullptr },
+      { "16", nullptr }, { "17", nullptr }, { "18", nullptr }, { "19", nullptr }, { "20", nullptr },
+      { "21", nullptr }, { "22", nullptr }, { "23", nullptr }, { "24", nullptr }, { "25", nullptr },
+      { "26", nullptr }, { "27", nullptr }, { "28", nullptr }, { "29", nullptr }, { "30", nullptr },
+      { "31", nullptr }, { "32", nullptr }, { "33", nullptr }, { "34", nullptr }, { "35", nullptr },
+      { "36", nullptr }, { "37", nullptr }, { "38", nullptr }, { "39", nullptr }, { "40", nullptr },
+      { "41", nullptr }, { "42", nullptr }, { "43", nullptr }, { "44", nullptr }, { "45", nullptr },
+      { "46", nullptr }, { "47", nullptr }, { "48", nullptr }, { "49", nullptr }, { "50", nullptr },
+      { nullptr, nullptr }
+    },
+    "0"
+  },
+  {
+    Libretro::Options::wiimote::IR_MODIFIER,
+    "WiiMote IR > Modifier Button",
+    "IR Modifier Button",
+    "Button used as a modifier for IR control. With no modifier selected, IR is always active with right thumbstick.",
+    nullptr,
+    CATEGORY_WIIMOTE,
+    {
+      { MODIFIER_NO_MODIFIER,   "None (Default)" },
+      { "L3",     nullptr },
+      { "R3",     nullptr },
+      { "L1",     nullptr },
+      { "R1",     nullptr },
+      { "L2",     nullptr },
+      { "R2",     nullptr },
+      { "A",      nullptr },
+      { "B",      nullptr },
+      { "X",      nullptr },
+      { "Y",      nullptr },
+      { "Start",  nullptr },
+      { "Select", nullptr },
+      { nullptr,  nullptr }
+    },
+    MODIFIER_NO_MODIFIER
+  },
+  {
+    Libretro::Options::wiimote::SWING_MODIFIER,
+    "WiiMote Swing > Modifier Button",
+    "Swing Modifier Button",
+    "Button to hold while using right thumbstick to activate swing. OFF turns off swing. Selecting none will allow free use of right thumb stick to swing (It will automatically filter out L3).",
+    nullptr,
+    CATEGORY_WIIMOTE,
+    {
+      { MODIFIER_DISABLED_CONTROL, "Disabled" },
+      { MODIFIER_NO_MODIFIER, "None" },
+      { "L3",     nullptr },
+      { "R3",     nullptr },
+      { "L1",     nullptr },
+      { "R1",     nullptr },
+      { "L2",     nullptr },
+      { "R2",     nullptr },
+      { "A",      nullptr },
+      { "B",      nullptr },
+      { "X",      nullptr },
+      { "Y",      nullptr },
+      { "Start",  nullptr },
+      { "Select", nullptr },
+      { nullptr,  nullptr }
+    },
+    MODIFIER_DISABLED_CONTROL
+  },
+  {
+    Libretro::Options::wiimote::SWING_ANGLE,
+    "Wiimote Swing > Angle",
+    "Swing Angle",
+    "Rotation applied at the extremities of a swing (1-180°).",
+    nullptr,
+    CATEGORY_WIIMOTE,
+    {
+      { "1",   nullptr }, { "5",   nullptr }, { "10",  nullptr }, { "15",  nullptr },
+      { "20",  nullptr }, { "25",  nullptr }, { "30",  nullptr }, { "35",  nullptr },
+      { "40",  nullptr }, { "45",  nullptr }, { "50",  nullptr }, { "55",  nullptr },
+      { "60",  nullptr }, { "65",  nullptr }, { "70",  nullptr }, { "75",  nullptr },
+      { "80",  nullptr }, { "85",  nullptr }, { "90",  "90° (Default)" },
+      { "100", nullptr }, { "110", nullptr }, { "120", nullptr }, { "130", nullptr },
+      { "140", nullptr }, { "150", nullptr }, { "160", nullptr }, { "170", nullptr },
+      { "180", nullptr },
+      { nullptr, nullptr }
+    },
+    "90"
+  },
+  {
+    Libretro::Options::wiimote::SAVE_LOAD_SETTINGS,
+    "Wiimote > Load & Prevent Save Settings",
+    "Load & Prevent Save Settings",
+    "Choose whether to load core settings from GCPad.ini/WiimoteNew.ini and also prevent saving to them. Core options may no longer be reflected correctly in RetroArch interface. Editing ini files incorrectly will likely crash the emulator.",
+    nullptr,
+    CATEGORY_WIIMOTE,
+    {
+      { "disabled", nullptr },
+      { "enabled",  nullptr },
+      { nullptr, nullptr }
+    },
+    "disabled"
   },
 
   { nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, {{0}}, nullptr }

--- a/Source/Core/DolphinLibretro/Common/Options.h
+++ b/Source/Core/DolphinLibretro/Common/Options.h
@@ -10,6 +10,9 @@
 #include "DiscIO/Enums.h"
 #include "VideoCommon/VideoConfig.h"
 
+#define MODIFIER_DISABLED_CONTROL "Disabled"
+#define MODIFIER_NO_MODIFIER "None"
+
 namespace Libretro
 {
 extern retro_environment_t environ_cb;
@@ -244,14 +247,27 @@ namespace gfx_hacks {
 }  // namespace gfx_hacks
 
 // ======================================================
-// Wiimote IR
+// Wiimote IR / Gyro / Swing
 // ======================================================
 namespace wiimote {
+  // Controllers
+  constexpr const char* DEFAULT_DEVICE = "dolphin_wiimote_default_device";
+
+  // General and options
+  constexpr const char HOTKEY_SIDEWAYS_TOGGLE[] = "dolphin_hotkey_sideways_toggle";
+
+  // Motion simulation
   constexpr const char IR_MODE[] = "dolphin_ir_mode";
   constexpr const char IR_OFFSET[] = "dolphin_ir_offset";
   constexpr const char IR_YAW[] = "dolphin_ir_yaw";
   constexpr const char IR_PITCH[] = "dolphin_ir_pitch";
-  constexpr const char* DEFAULT_DEVICE = "dolphin_wiimote_default_device";
+  constexpr const char IR_DEADZONE[] = "dolphin_ir_deadzone";
+  constexpr const char IR_MODIFIER[] = "dolphin_ir_modifier";
+  constexpr const char SWING_MODIFIER[] = "dolphin_swing_modifier";
+  constexpr const char SWING_ANGLE[] = "dolphin_swing_angle";
+
+  // preserve settings
+  constexpr const char SAVE_LOAD_SETTINGS[] = "dolphin_save_load_settings";
 }  // namespace wiimote
 }  // namespace Options
 }  // namespace Libretro

--- a/Source/Core/DolphinLibretro/Common/Options.h
+++ b/Source/Core/DolphinLibretro/Common/Options.h
@@ -251,6 +251,7 @@ namespace wiimote {
   constexpr const char IR_OFFSET[] = "dolphin_ir_offset";
   constexpr const char IR_YAW[] = "dolphin_ir_yaw";
   constexpr const char IR_PITCH[] = "dolphin_ir_pitch";
+  constexpr const char* DEFAULT_DEVICE = "dolphin_wiimote_default_device";
 }  // namespace wiimote
 }  // namespace Options
 }  // namespace Libretro

--- a/Source/Core/DolphinLibretro/Input.cpp
+++ b/Source/Core/DolphinLibretro/Input.cpp
@@ -46,6 +46,12 @@
 #define RETRO_DEVICE_GC_ON_WII ((6 << 8) | RETRO_DEVICE_JOYPAD)
 #define RETRO_DEVICE_REAL_WIIMOTE ((6 << 8) | RETRO_DEVICE_NONE)
 
+typedef enum {
+    SENSOR_ACCELEROMETER = 0,
+    SENSOR_GYRO,
+    SENSOR_COUNT
+} sensor_type_t;
+
 void retro_set_controller_port_device_gc(unsigned port, unsigned device);
 void retro_set_controller_port_device_wii(unsigned port, unsigned device);
 
@@ -57,9 +63,15 @@ namespace Input
 static retro_input_poll_t poll_cb = nullptr;
 static retro_input_state_t input_cb = nullptr;
 static struct retro_rumble_interface rumble{};
-static const std::string source = "Libretro";
 static unsigned input_types[8];
 static bool g_init_wiimotes = false;
+static unsigned s_default_device = RETRO_DEVICE_WIIMOTE;
+static bool s_sensor_init_pending = false;
+static bool sensor_enabled[NUM_CONTROLLERS_FOR_SENSORS][SENSOR_COUNT] = {};
+static int port_max;
+double g_accel_pos[NUM_CONTROLLERS_FOR_SENSORS][3] = {}; // x, y, z
+double g_accel_neg[NUM_CONTROLLERS_FOR_SENSORS][3] = {}; // x, y, z
+double g_gyro[NUM_CONTROLLERS_FOR_SENSORS][3] = {};
 
 static struct retro_input_descriptor descGC[] = {
     {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT, "Left"},
@@ -235,7 +247,11 @@ static std::string GetDeviceName(unsigned device)
 
 static std::string GetQualifiedName(unsigned port, unsigned device)
 {
-  return ciface::Core::DeviceQualifier(source, port, GetDeviceName(device)).ToString();
+  return ciface::Core::DeviceQualifier(
+      std::string(source),
+      static_cast<int>(port),
+      GetDeviceName(device)
+  ).ToString();
 }
 
 class Device : public ciface::Core::Device
@@ -325,7 +341,7 @@ public:
     return ciface::Core::DeviceRemoval::Keep;
   }
   std::string GetName() const override { return GetDeviceName(m_device); }
-  std::string GetSource() const override { return source; }
+  std::string GetSource() const override { return std::string(source); }
   unsigned int GetPort() const { return m_port; }
 
 private:
@@ -446,6 +462,11 @@ void Init(const WindowSystemInfo& wsi)
     WARN_LOG_FMT(COMMON, "RetroArch does not support RETRO_ENVIRONMENT_GET_RUMBLE_INTERFACE.");
   }
 
+  if (!environ_cb(RETRO_ENVIRONMENT_GET_SENSOR_INTERFACE, &sensor_interface))
+  {
+    WARN_LOG_FMT(COMMON, "RetroArch does not support RETRO_ENVIRONMENT_GET_SENSOR_INTERFACE.");
+  }
+
   g_controller_interface.Initialize(wsi);
   g_controller_interface.AddDevice(std::make_shared<Device>(RETRO_DEVICE_KEYBOARD, 0));
 
@@ -455,12 +476,14 @@ void Init(const WindowSystemInfo& wsi)
   Keyboard::Initialize();
   FreeLook::Initialize();
 
-  int port_max = (Core::System::GetInstance().IsWii() &&
+  port_max = (Core::System::GetInstance().IsWii() &&
     Libretro::Options::GetCached<int>(Libretro::Options::sysconf::ALT_GC_PORTS_ON_WII)) ? 8 : 4;
   for (int i = 0; i < port_max; i++)
     Libretro::Input::AddDevicesForPort(i);
 
   g_init_wiimotes = true;
+  s_sensor_init_pending = true;
+
   Wiimote::Initialize(Wiimote::InitializeMode::DO_NOT_WAIT_FOR_WIIMOTES);
 }
 
@@ -475,7 +498,7 @@ void InitStage2()
     // Wii devices listed in ports 1-4, GC controllers in ports 5-8
     if (Libretro::Options::GetCached<int>(Libretro::Options::sysconf::ALT_GC_PORTS_ON_WII))
     {
-      static const struct retro_controller_description wiimote_desc[] = {
+      static struct retro_controller_description wiimote_desc[] = {
           {"WiiMote", RETRO_DEVICE_WIIMOTE},
           {"WiiMote (sideways)", RETRO_DEVICE_WIIMOTE_SW},
           {"WiiMote + Nunchuk", RETRO_DEVICE_WIIMOTE_NC},
@@ -484,7 +507,7 @@ void InitStage2()
           {"Real WiiMote", RETRO_DEVICE_REAL_WIIMOTE},
       };
 
-      static const struct retro_controller_info ports[] = {
+      const struct retro_controller_info ports[] = {
           {wiimote_desc, sizeof(wiimote_desc) / sizeof(*wiimote_desc)},
           {wiimote_desc, sizeof(wiimote_desc) / sizeof(*wiimote_desc)},
           {wiimote_desc, sizeof(wiimote_desc) / sizeof(*wiimote_desc)},
@@ -497,13 +520,11 @@ void InitStage2()
       };
 
       if (!environ_cb(RETRO_ENVIRONMENT_SET_CONTROLLER_INFO, (void*)ports))
-      {
         WARN_LOG_FMT(COMMON, "RetroArch does not support RETRO_ENVIRONMENT_SET_CONTROLLER_INFO.");
-      }
     }
     else // Both Wii devices and GC controllers listed in ports 1-4, ports 5-8 are unused
     {
-      static const struct retro_controller_description wii_and_gc_desc[] = {
+      static struct retro_controller_description wii_and_gc_desc[] = {
           {"WiiMote", RETRO_DEVICE_WIIMOTE},
           {"WiiMote (sideways)", RETRO_DEVICE_WIIMOTE_SW},
           {"WiiMote + Nunchuk", RETRO_DEVICE_WIIMOTE_NC},
@@ -513,7 +534,7 @@ void InitStage2()
           {"GameCube Controller", RETRO_DEVICE_GC_ON_WII},
       };
 
-      static const struct retro_controller_info ports[] = {
+      const struct retro_controller_info ports[] = {
           {wii_and_gc_desc, sizeof(wii_and_gc_desc) / sizeof(*wii_and_gc_desc)},
           {wii_and_gc_desc, sizeof(wii_and_gc_desc) / sizeof(*wii_and_gc_desc)},
           {wii_and_gc_desc, sizeof(wii_and_gc_desc) / sizeof(*wii_and_gc_desc)},
@@ -522,9 +543,7 @@ void InitStage2()
       };
 
       if (!environ_cb(RETRO_ENVIRONMENT_SET_CONTROLLER_INFO, (void*)ports))
-      {
         WARN_LOG_FMT(COMMON, "RetroArch does not support RETRO_ENVIRONMENT_SET_CONTROLLER_INFO.");
-      }
     }
   }
   else
@@ -538,10 +557,46 @@ void InitStage2()
     };
 
     if (!environ_cb(RETRO_ENVIRONMENT_SET_CONTROLLER_INFO, (void*)ports))
-    {
       WARN_LOG_FMT(COMMON, "RetroArch does not support RETRO_ENVIRONMENT_SET_CONTROLLER_INFO.");
+  }
+}
+
+void InitSensors()
+{
+  if (!s_sensor_init_pending)
+    return;
+
+  // sensors do not apply to GC and neither does default controller
+  if (!Core::System::GetInstance().IsWii())
+  {
+    s_sensor_init_pending = false;
+    return;
+  }
+
+  port_max = (Core::System::GetInstance().IsWii() &&
+    Libretro::Options::GetCached<int>(Libretro::Options::sysconf::ALT_GC_PORTS_ON_WII)) ? 8 : 4;
+
+  for (int i = 0; i < port_max; i++)
+  {
+    if (sensor_interface.set_sensor_state)
+    {
+      sensor_enabled[i][SENSOR_ACCELEROMETER] = sensor_interface.set_sensor_state(i, RETRO_SENSOR_ACCELEROMETER_ENABLE, 60);
+      sensor_enabled[i][SENSOR_GYRO] = sensor_interface.set_sensor_state(i, RETRO_SENSOR_GYROSCOPE_ENABLE, 60);
+
+      if (sensor_enabled[i][SENSOR_ACCELEROMETER] || sensor_enabled[i][SENSOR_GYRO])
+      {
+        auto sensor = std::make_shared<SensorDevice>(i);
+        sensor->RegisterAll();
+        g_controller_interface.AddDevice(sensor);
+      }
+
+      INFO_LOG_FMT(COMMON, "Sensor interface: Port: {} ACCELEROMETER: {} GYROSCOPE: {}", i,
+        sensor_enabled[i][SENSOR_ACCELEROMETER], sensor_enabled[i][SENSOR_GYRO]);
     }
   }
+
+  s_sensor_init_pending = false;
+  ResetControllers();
 }
 
 void Shutdown()
@@ -556,8 +611,19 @@ void Shutdown()
 #if defined(__LIBUSB__)
   GCAdapter::ResetRumble();
 #endif
-  for (int i = 0; i < 4; ++i)
+  for (int i = 0; i < port_max; ++i)
+  {
     Pad::ResetRumble(i);
+
+    if(sensor_enabled[i][SENSOR_ACCELEROMETER])
+      sensor_interface.set_sensor_state(0, RETRO_SENSOR_GYROSCOPE_DISABLE, 0);
+
+    if(sensor_enabled[i][SENSOR_GYRO])
+      sensor_interface.set_sensor_state(0, RETRO_SENSOR_ACCELEROMETER_DISABLE, 0);
+
+    sensor_enabled[i][SENSOR_ACCELEROMETER] = false;
+    sensor_enabled[i][SENSOR_GYRO] = false;
+  }
 
   Keyboard::Shutdown();
   Pad::Shutdown();
@@ -566,22 +632,33 @@ void Shutdown()
   rumble.set_rumble_state = nullptr;
 }
 
-void Update()
+void UpdateAccelerometer(unsigned port)
 {
-  if (poll_cb)
-    poll_cb();
-#ifdef __ANDROID__
-  /* Android doesn't support input polling on all threads by default
-   * this will force the poll for this frame to happen in the main thread
-   * in case the frontend is doing late-polling */
-  if (input_cb)
-    input_cb(0, 0, 0, 0);
-#endif
+  if (!sensor_enabled[port][SENSOR_ACCELEROMETER] || !sensor_interface.get_sensor_input)
+    return;
+
+  static const float G = 9.80665f;
+
+  for (int i = 0; i < 3; i++)
+  {
+    float v = sensor_interface.get_sensor_input(port, RETRO_SENSOR_ACCELEROMETER_X + i) * G;
+    g_accel_pos[port][i] = std::max(0.0f, v);
+    g_accel_neg[port][i] = std::max(0.0f, -v);
+  }
+}
+
+void UpdateGyro(unsigned port)
+{
+  if (!sensor_enabled[port][SENSOR_GYRO] || !sensor_interface.get_sensor_input)
+    return;
+
+  for (int i = 0; i < 3; i++)
+    g_gyro[port][i] = sensor_interface.get_sensor_input(port, RETRO_SENSOR_GYROSCOPE_X + i);
 }
 
 void ResetControllers()
 {
-  for (int port = 0; port < 4; port++)
+  for (int port = 0; port < port_max; port++)
     retro_set_controller_port_device(port, input_types[port]);
 }
 
@@ -598,6 +675,34 @@ void BluetoothPassthroughBind()
   }
 
   was_pressed = sync;
+}
+
+void Update()
+{
+  if (poll_cb)
+    poll_cb();
+#ifdef __ANDROID__
+  /* Android doesn't support input polling on all threads by default
+   * this will force the poll for this frame to happen in the main thread
+   * in case the frontend is doing late-polling */
+  if (input_cb)
+    input_cb(0, 0, 0, 0);
+#endif
+
+  for (int i = 0; i < port_max; ++i)
+  {
+    UpdateAccelerometer(i);
+    UpdateGyro(i);
+  }
+}
+
+static std::string GetQualifiedNameSensor(unsigned port)
+{
+  return ciface::Core::DeviceQualifier(
+      std::string(Libretro::Input::source),
+      static_cast<int>(port),
+      std::string("Sensor")
+  ).ToString();
 }
 
 }  // namespace Input
@@ -943,10 +1048,55 @@ void retro_set_controller_port_device_wii(unsigned port, unsigned device)
         wmButtons->SetControlExpression(2, "B");  // 1
         wmButtons->SetControlExpression(3, "A");  // 2
       }
-      wmTilt->SetControlExpression(0, "`" + devAnalog + ":Y0-`");  // Forward
-      wmTilt->SetControlExpression(1, "`" + devAnalog + ":Y0+`");  // Backward
-      wmTilt->SetControlExpression(2, "`" + devAnalog + ":X0-`");  // Left
-      wmTilt->SetControlExpression(3, "`" + devAnalog + ":X0+`");  // Right
+
+      // Map accel data to tilt expressions
+      if (Libretro::Input::sensor_enabled[port][SENSOR_ACCELEROMETER] ||
+          Libretro::Input::sensor_enabled[port][SENSOR_GYRO])
+      {
+        std::string devSensor = Libretro::Input::GetQualifiedNameSensor(port);
+
+        if (Libretro::Input::sensor_enabled[port][SENSOR_ACCELEROMETER])
+        {
+          // Accelerometer (6 inputs: Up, Down, Left, Right, Forward, Backward)
+          // Indices must match WiimoteEmu::LoadDefaults ordering (0..5)
+          auto* wmAccel = static_cast<ControllerEmu::IMUAccelerometer*>(
+            wm->GetWiimoteGroup(WiimoteEmu::WiimoteGroup::IMUAccelerometer));
+          if (wmAccel)
+          {
+            wmAccel->SetControlExpression(0, "`" + devSensor + ":AccelZ+`");  // Up
+            wmAccel->SetControlExpression(1, "`" + devSensor + ":AccelZ-`");  // Down
+            wmAccel->SetControlExpression(2, "`" + devSensor + ":AccelX+`");  // Left
+            wmAccel->SetControlExpression(3, "`" + devSensor + ":AccelX-`");  // Right
+            wmAccel->SetControlExpression(4, "`" + devSensor + ":AccelY-`");  // Forward
+            wmAccel->SetControlExpression(5, "`" + devSensor + ":AccelY+`");  // Backward
+          }
+
+          if (Libretro::Input::sensor_enabled[port][SENSOR_GYRO])
+          {
+            // Gyroscope (6 inputs: PitchUp/Down, RollLeft/Right, YawLeft/Right)
+            auto* wmGyro = static_cast<ControllerEmu::IMUGyroscope*>(
+              wm->GetWiimoteGroup(WiimoteEmu::WiimoteGroup::IMUGyroscope));
+            if (wmGyro)
+            {
+              // Map libretro axes to Wiimote angular axes:
+              // Pitch ~ rotation around X, Roll ~ rotation around Y, Yaw ~ rotation around Z
+              wmGyro->SetControlExpression(0, "`" + devSensor + ":GyroX`");       // Pitch Up
+              wmGyro->SetControlExpression(1, "`" + devSensor + ":GyroX`*-1");    // Pitch Down
+              wmGyro->SetControlExpression(2, "`" + devSensor + ":GyroY`*-1");    // Roll Left
+              wmGyro->SetControlExpression(3, "`" + devSensor + ":GyroY`");       // Roll Right
+              wmGyro->SetControlExpression(4, "`" + devSensor + ":GyroZ`*-1");    // Yaw Left
+              wmGyro->SetControlExpression(5, "`" + devSensor + ":GyroZ`");       // Yaw Right
+            }
+          }
+        }
+      }
+      else
+      {
+        wmTilt->SetControlExpression(0, "`" + devAnalog + ":Y0-`");  // Forward
+        wmTilt->SetControlExpression(1, "`" + devAnalog + ":Y0+`");  // Backward
+        wmTilt->SetControlExpression(2, "`" + devAnalog + ":X0-`");  // Left
+        wmTilt->SetControlExpression(3, "`" + devAnalog + ":X0+`");  // Right
+      }
       wmButtons->SetControlExpression(4, "Select");                // -
       wmButtons->SetControlExpression(5, "Start");                 // +
     }
@@ -1022,7 +1172,9 @@ void retro_set_controller_port_device_wii(unsigned port, unsigned device)
 
   case RETRO_DEVICE_WIIMOTE_SW:
     wmExtension->SetSelectedAttachment(ExtensionNumber::NONE);
-     static_cast<ControllerEmu::NumericSetting<bool>*>(wmOptions->numeric_settings[3].get())
+    // Only set sideways if NOT using real sensor data due to extra rotation applied
+    if (!Libretro::Input::sensor_enabled[port][SENSOR_ACCELEROMETER])
+      static_cast<ControllerEmu::NumericSetting<bool>*>(wmOptions->numeric_settings[3].get())
         ->SetValue(true);  // Sideways Wiimote
     Config::SetBaseOrCurrent(Config::GetInfoForWiimoteSource(port), WiimoteSource::Emulated);
     WiimoteCommon::OnSourceChanged(port, WiimoteSource::Emulated);

--- a/Source/Core/DolphinLibretro/Input.cpp
+++ b/Source/Core/DolphinLibretro/Input.cpp
@@ -4,7 +4,9 @@
 #include <libretro.h>
 
 #include "Common/Common.h"
+#include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
+#include "Common/FileUtil.h"
 #include "Common/IniFile.h"
 #include "Common/Logging/Log.h"
 #include "Core/Config/MainSettings.h"
@@ -37,6 +39,7 @@
 #include "InputCommon/GCAdapter.h"
 #include "InputCommon/GCPadStatus.h"
 #include "InputCommon/InputConfig.h"
+#include "InputCommon/InputProfile.h"
 
 #define RETRO_DEVICE_WIIMOTE RETRO_DEVICE_JOYPAD
 #define RETRO_DEVICE_WIIMOTE_SW ((2 << 8) | RETRO_DEVICE_JOYPAD)
@@ -65,7 +68,6 @@ static retro_input_state_t input_cb = nullptr;
 static struct retro_rumble_interface rumble{};
 static unsigned input_types[8];
 static bool g_init_wiimotes = false;
-static unsigned s_default_device = RETRO_DEVICE_WIIMOTE;
 static bool s_sensor_init_pending = false;
 static bool sensor_enabled[NUM_CONTROLLERS_FOR_SENSORS][SENSOR_COUNT] = {};
 static int port_max;
@@ -167,7 +169,7 @@ static struct retro_input_descriptor descWiimote[] = {
     {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2, "Shake Wiimote"},
     {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START, "+"},
     {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, "-"},
-    {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3, "Sideways Toggle"},
+    //{0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3, "Sideways Toggle"},
     {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3, "Home"},
     {0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X,
     "Tilt Left/Right"},
@@ -188,7 +190,7 @@ static struct retro_input_descriptor descWiimoteSideways[] = {
     {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2, "Shake Wiimote"},
     {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START, "+"},
     {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, "-"},
-    {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3, "Sideways Toggle"},
+    //{0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3, "Sideways Toggle"},
     {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3, "Home"},
     {0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X,
     "Tilt Left/Right"},
@@ -212,7 +214,7 @@ static struct retro_input_descriptor descWiimoteNunchuk[] = {
     {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2, "Shake Nunchuk"},
     {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START, "1"},
     {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, "2"},
-    {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3, "Sideways Toggle"},
+    //{0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3, "Sideways Toggle"},
     {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3, "Home"},
     {0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X,
     "Nunchuk Stick X"},
@@ -566,8 +568,8 @@ void InitSensors()
   if (!s_sensor_init_pending)
     return;
 
-  // sensors do not apply to GC and neither does default controller
-  if (!Core::System::GetInstance().IsWii())
+  // sensors do not apply to GC, bluetooth passthrough and neither does default controller
+  if (!Core::System::GetInstance().IsWii() || Config::Get(Config::MAIN_BLUETOOTH_PASSTHROUGH_ENABLED))
   {
     s_sensor_init_pending = false;
     return;
@@ -596,7 +598,8 @@ void InitSensors()
   }
 
   s_sensor_init_pending = false;
-  ResetControllers();
+
+  ResetControllers(WiimoteUpdateFlags{});
 }
 
 void Shutdown()
@@ -656,8 +659,16 @@ void UpdateGyro(unsigned port)
     g_gyro[port][i] = sensor_interface.get_sensor_input(port, RETRO_SENSOR_GYROSCOPE_X + i);
 }
 
-void ResetControllers()
+void ResetControllers(const WiimoteUpdateFlags& f)
 {
+  // only update what has changed
+  if (f.any())
+  {
+    for (int port = 0; port < 4; port++)
+      UpdateWiimoteMappings(f, port, input_types[port]);
+    return;
+  }
+
   for (int port = 0; port < port_max; port++)
     retro_set_controller_port_device(port, input_types[port]);
 }
@@ -703,6 +714,186 @@ static std::string GetQualifiedNameSensor(unsigned port)
       static_cast<int>(port),
       std::string("Sensor")
   ).ToString();
+}
+
+// can be called from retro_run, do not reset all settings because one thing changed
+void UpdateWiimoteMappings(const WiimoteUpdateFlags& f, unsigned port, unsigned device)
+{
+  if (!f.any() || device == RETRO_DEVICE_REAL_WIIMOTE || device == RETRO_DEVICE_WIIMOTE_CC ||
+    device == RETRO_DEVICE_WIIMOTE_CC_PRO)
+    return;
+
+  auto& system = Core::System::GetInstance();
+  bool altGCPorts = Libretro::Options::GetCached<bool>(Libretro::Options::sysconf::ALT_GC_PORTS_ON_WII);
+
+  if (((!system.IsWii() || !altGCPorts) && port > 3) || port > 7)
+    return;
+
+  // modifier wrapper
+  auto wrap = [](const std::string& mod, const std::string& expr) {
+    if (mod == MODIFIER_NO_MODIFIER || mod.empty())
+      return expr;                   // no modifier - always active
+    return mod + " & " + expr;       // modifier held - active
+  };
+
+  WiimoteEmu::Wiimote* wm = (WiimoteEmu::Wiimote*)Wiimote::GetConfig()->GetController(port);
+
+  // IR‑related updates
+  if (f.irModifier ||
+      f.irMode ||
+      f.irOffset ||
+      f.irYaw ||
+      f.irPitch ||
+      f.irDeadzone ||
+      f.swingModifier)
+  {
+    ControllerEmu::ControlGroup* wmIR = wm->GetWiimoteGroup(WiimoteEmu::WiimoteGroup::Point);
+    const int irMode = Libretro::Options::GetCached<int>(Libretro::Options::wiimote::IR_MODE);
+
+    if (f.irOffset)
+    {
+      const int irCenter = Libretro::Options::GetCached<int>(Libretro::Options::wiimote::IR_OFFSET);
+      static_cast<ControllerEmu::NumericSetting<double>*>(wmIR->numeric_settings[1].get())
+        ->SetValue(irCenter); // IR Vertical Offset
+    }
+
+    if (f.irYaw)
+    {
+      const int irWidth = Libretro::Options::GetCached<int>(Libretro::Options::wiimote::IR_YAW);
+      static_cast<ControllerEmu::NumericSetting<double>*>(wmIR->numeric_settings[2].get())
+        ->SetValue(irWidth);  // IR Total Yaw
+    }
+
+    if (f.irPitch)
+    {
+      const int irHeight = Libretro::Options::GetCached<int>(Libretro::Options::wiimote::IR_PITCH);
+      static_cast<ControllerEmu::NumericSetting<double>*>(wmIR->numeric_settings[3].get())
+        ->SetValue(irHeight); // IR Total Pitch
+    }
+
+
+    if (f.irMode || f.irModifier || f.swingModifier)
+    {
+      std::string devAnalog = Libretro::Input::GetQualifiedName(port, RETRO_DEVICE_ANALOG);
+      std::string devPointer = Libretro::Input::GetQualifiedName(port, RETRO_DEVICE_POINTER);
+
+      if (irMode == 0 || irMode == 1)
+      {
+        // Set right stick to control the IR
+        std::string irMod = Libretro::Options::GetCached<std::string>(Libretro::Options::wiimote::IR_MODIFIER);
+        wmIR->SetControlExpression(0, wrap(irMod, "`" + devAnalog + ":Y1-`")); // Up
+        wmIR->SetControlExpression(1, wrap(irMod, "`" + devAnalog + ":Y1+`")); // Down
+        wmIR->SetControlExpression(2, wrap(irMod, "`" + devAnalog + ":X1-`")); // Left
+        wmIR->SetControlExpression(3, wrap(irMod, "`" + devAnalog + ":X1+`")); // Right
+
+        static_cast<ControllerEmu::NumericSetting<bool>*>(wmIR->numeric_settings[4].get())
+          ->SetValue(irMode == 0);                                    // Relative input
+        static_cast<ControllerEmu::NumericSetting<bool>*>(wmIR->numeric_settings[5].get())
+          ->SetValue(true);                                           // Auto hide
+
+        // Swing‑related updates
+        ControllerEmu::ControlGroup* wmSwing = wm->GetWiimoteGroup(WiimoteEmu::WiimoteGroup::Swing);
+
+        // modifier controls swing plus analog
+        std::string swingModifier = Libretro::Options::GetCached<std::string>(Libretro::Options::wiimote::SWING_MODIFIER);
+
+        if (swingModifier != MODIFIER_DISABLED_CONTROL)
+        {
+          // we don't want whatever the irMod is set to (e.g. L3) to interfere with swinging
+          if (swingModifier == MODIFIER_NO_MODIFIER && irMod != swingModifier)
+            swingModifier = "!" + irMod;
+
+          wmSwing->SetControlExpression(0, wrap(swingModifier, "`" + devAnalog + ":Y1-`"));  // Up
+          wmSwing->SetControlExpression(1, wrap(swingModifier, "`" + devAnalog + ":Y1+`"));  // Down
+          wmSwing->SetControlExpression(2, wrap(swingModifier, "`" + devAnalog + ":X1-`"));  // Left
+          wmSwing->SetControlExpression(3, wrap(swingModifier, "`" + devAnalog + ":X1+`"));  // Right
+        }
+        else
+        {
+          wmSwing->SetControlExpression(0, "");
+          wmSwing->SetControlExpression(1, "");
+          wmSwing->SetControlExpression(2, "");
+          wmSwing->SetControlExpression(3, "");
+        }
+      }
+      else
+      {
+        // Mouse controls IR
+        wmIR->SetControlExpression(0, "`" + devPointer + ":Y0-`");    // Up
+        wmIR->SetControlExpression(1, "`" + devPointer + ":Y0+`");    // Down
+        wmIR->SetControlExpression(2, "`" + devPointer + ":X0-`");    // Left
+        wmIR->SetControlExpression(3, "`" + devPointer + ":X0+`");    // Right
+        static_cast<ControllerEmu::NumericSetting<bool>*>(wmIR->numeric_settings[4].get())
+          ->SetValue(false);                                          // Relative input
+        static_cast<ControllerEmu::NumericSetting<bool>*>(wmIR->numeric_settings[5].get())
+          ->SetValue(false);                                          // Auto hide
+      }
+
+      if (f.irMode && device == RETRO_DEVICE_WIIMOTE_NC)
+      {
+        // mouse
+        if (irMode != 0 && irMode != 1)
+        {
+          ControllerEmu::ControlGroup* wmTilt = wm->GetWiimoteGroup(WiimoteEmu::WiimoteGroup::Tilt);
+          wmTilt->SetControlExpression(0, "`" + devAnalog + ":Y1-`");  // Forward
+          wmTilt->SetControlExpression(1, "`" + devAnalog + ":Y1+`");  // Backward
+          wmTilt->SetControlExpression(2, "`" + devAnalog + ":X1-`");  // Left
+          wmTilt->SetControlExpression(3, "`" + devAnalog + ":X1+`");  // Right
+        }
+      }
+    }
+
+    if (f.irDeadzone)
+    {
+      const int irDeadzone = Libretro::Options::GetCached<int>(Libretro::Options::wiimote::IR_DEADZONE);
+      static_cast<ControllerEmu::NumericSetting<double>*>(wmIR->numeric_settings[0].get())
+        ->SetValue(irDeadzone); // IR DeadZone
+    }
+  }
+
+  if (f.swingAngle)
+  {
+    ControllerEmu::ControlGroup* wmSwing = wm->GetWiimoteGroup(WiimoteEmu::WiimoteGroup::Swing);
+
+    const int swingAngle = Libretro::Options::GetCached<int>(Libretro::Options::wiimote::SWING_ANGLE);
+    static_cast<ControllerEmu::NumericSetting<double>*>(wmSwing->numeric_settings[0].get())
+      ->SetValue(swingAngle);                                           // Swing/Angle
+  }
+
+  // Sideways toggle
+  if (f.sideways)
+  {
+    ControllerEmu::ControlGroup* wmHotkeys = wm->GetWiimoteGroup(WiimoteEmu::WiimoteGroup::Hotkeys);
+    std::string sidewaysToggle =
+      Libretro::Options::GetCached<std::string>(Libretro::Options::wiimote::HOTKEY_SIDEWAYS_TOGGLE);
+
+    wmHotkeys->SetControlExpression(0,
+      sidewaysToggle != MODIFIER_DISABLED_CONTROL ? sidewaysToggle : "");  // Sideways Toggle (L3 default)
+
+#if 0
+    wmHotkeys->SetControlExpression(1, "");  // Upright Toggle
+    wmHotkeys->SetControlExpression(2, "");  // Sideways Hold
+    wmHotkeys->SetControlExpression(3, "");  // Upright Hold
+#endif
+  }
+
+  // Rumble
+  if (f.rumble)
+  {
+    ControllerEmu::ControlGroup* wmRumble = wm->GetWiimoteGroup(WiimoteEmu::WiimoteGroup::Rumble);
+    bool enableRumble = Libretro::Options::GetCached<bool>(Libretro::Options::sysconf::ENABLE_RUMBLE);
+    if (enableRumble)
+      wmRumble->SetControlExpression(0, "Rumble");
+  }
+
+  if (f.any())
+  {
+    wm->UpdateReferences(g_controller_interface);
+
+    bool saveOrLoad = Libretro::Options::GetCached<bool>(Libretro::Options::wiimote::SAVE_LOAD_SETTINGS);
+    if (!saveOrLoad)
+      ::Wiimote::GetConfig()->SaveConfig();
+  }
 }
 
 }  // namespace Input
@@ -819,6 +1010,92 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
   }
 }
 
+void refresh_all_wiimote_flags(unsigned port, unsigned device)
+{
+  WiimoteUpdateFlags f;
+  f.sideways     = true;
+  f.irModifier   = true;
+  f.swingModifier = true;
+  f.irMode       = true;
+  f.irOffset     = true;
+  f.irYaw        = true;
+  f.irPitch      = true;
+  f.irDeadzone   = true;
+  f.swingAngle   = true;
+  f.rumble       = true;
+  Libretro::Input::UpdateWiimoteMappings(f, port, device);
+}
+
+// Mirror InputConfig::LoadConfig() for a single port.
+//  1) game-specific input profile (game ini [Controls] WiimoteProfile{n}),
+//  2) WiimoteNew.ini [Wiimote{n}] section,
+// Returns the configured Wiimote pointer if a saved config was found and loaded,
+// nullptr if the caller should apply hard-coded defaults instead.
+// SetDefaultDevice is always called before UpdateReferences so profiles without
+// a Device= line still bind to the correct libretro joypad.
+static WiimoteEmu::Wiimote* load_saved_controller_config(unsigned port, unsigned device)
+{
+  bool saveOrLoad = Libretro::Options::GetCached<bool>(Libretro::Options::wiimote::SAVE_LOAD_SETTINGS);
+  if (!saveOrLoad)
+    return nullptr;
+
+  WiimoteEmu::Wiimote* wm =
+      (WiimoteEmu::Wiimote*)Wiimote::GetConfig()->GetController(port);
+
+  // Rebuild devJoypad here so SetDefaultDevice is always called inside this
+  // function, before UpdateReferences, regardless of which load path fires.
+  const std::string devJoypad = Libretro::Input::GetQualifiedName(port, RETRO_DEVICE_JOYPAD);
+
+  const std::string profile_directory = ::Wiimote::GetConfig()->GetUserProfileDirectoryPath();
+  const std::string profile_key =
+      fmt::format("{}Profile{}", ::Wiimote::GetConfig()->GetProfileKey(), port + 1);
+
+  // Step 1: game ini [Controls] WiimoteProfile{n} -> Profiles/Wiimote/<name>.ini [Profile]
+  // LoadGameIni() already resolves the priority chain: S.ini, SOE.ini, SOUE01.ini, SOUE01r{n}.ini
+  Common::IniFile game_ini = SConfig::GetInstance().LoadGameIni();
+  const auto* control_section = game_ini.GetOrCreateSection("Controls");
+  std::string profile_setting;
+  if (control_section->Get(profile_key, &profile_setting))
+  {
+    const auto profiles = InputProfile::GetProfilesFromSetting(profile_setting, profile_directory);
+    if (!profiles.empty())
+    {
+      Common::IniFile profile_ini;
+      if (profile_ini.Load(profiles[0]))
+      {
+        Common::IniFile::Section* profile_sec = profile_ini.GetOrCreateSection("Profile");
+        wm->LoadConfig(profile_sec);
+        wm->SetDefaultDevice(devJoypad);
+        wm->UpdateReferences(g_controller_interface);
+        refresh_all_wiimote_flags(port, device);
+        ::Wiimote::GetConfig()->SaveConfig();
+        return wm;  // Per-game profile loaded
+      }
+    }
+  }
+
+  // Step 2: WiimoteNew.ini [Wiimote{n}] - GetSection not GetOrCreateSection so a
+  // missing section doesn't silently bypass the hard-coded defaults in the caller.
+  const std::string wiimote_ini_path =
+      File::GetUserPath(D_CONFIG_IDX) + WIIMOTE_INI_NAME ".ini";
+  Common::IniFile wiimote_new_ini;
+  if (wiimote_new_ini.Load(wiimote_ini_path))
+  {
+    Common::IniFile::Section* wm_sec = wiimote_new_ini.GetSection(wm->GetName());
+    if (wm_sec)
+    {
+      wm->LoadConfig(wm_sec);
+      wm->SetDefaultDevice(devJoypad);
+      wm->UpdateReferences(g_controller_interface);
+      refresh_all_wiimote_flags(port, device);
+      ::Wiimote::GetConfig()->SaveConfig();
+      return wm;  // WiimoteNew.ini loaded
+    }
+  }
+
+  return nullptr;  // nothing found, applies hard-coded defaults
+}
+
 void retro_set_controller_port_device_gc(unsigned port, unsigned device)
 {
   std::string devJoypad = Libretro::Input::GetQualifiedName(port, RETRO_DEVICE_JOYPAD);
@@ -894,7 +1171,10 @@ void retro_set_controller_port_device_gc(unsigned port, unsigned device)
     ->SetValue(true); // Always Connected
 
   gcPad->UpdateReferences(g_controller_interface);
-  Pad::GetConfig()->SaveConfig();
+
+  bool saveOrLoad = Libretro::Options::GetCached<bool>(Libretro::Options::wiimote::SAVE_LOAD_SETTINGS);
+  if (!saveOrLoad)
+    return Pad::GetConfig()->SaveConfig();
 }
 
 void retro_set_controller_port_device_wii(unsigned port, unsigned device)
@@ -922,11 +1202,21 @@ void retro_set_controller_port_device_wii(unsigned port, unsigned device)
     si.ChangeDevice(Config::Get(Config::GetInfoForSIDevice(port)), port);
   }
 
-  WiimoteEmu::Wiimote* wm = (WiimoteEmu::Wiimote*)Wiimote::GetConfig()->GetController(port);
+  WiimoteEmu::Wiimote* wm = load_saved_controller_config(port, device);
+
+  // defaults already found, so don't overwrite
+  if (wm)
+    return;
+
+  // nothing found — start fresh and apply hard-coded defaults
+  wm = (WiimoteEmu::Wiimote*)Wiimote::GetConfig()->GetController(port);
+
   // load an empty inifile section, clears everything
   Common::IniFile::Section sec;
   wm->LoadConfig(&sec);
   wm->SetDefaultDevice(devJoypad);
+
+  WiimoteUpdateFlags f;
 
   using namespace WiimoteEmu;
   if (device == RETRO_DEVICE_WIIMOTE_CC || device == RETRO_DEVICE_WIIMOTE_CC_PRO)
@@ -977,26 +1267,14 @@ void retro_set_controller_port_device_wii(unsigned port, unsigned device)
   {
     ControllerEmu::ControlGroup* wmButtons = wm->GetWiimoteGroup(WiimoteGroup::Buttons);
     ControllerEmu::ControlGroup* wmDPad = wm->GetWiimoteGroup(WiimoteGroup::DPad);
-    ControllerEmu::ControlGroup* wmIR = wm->GetWiimoteGroup(WiimoteGroup::Point);
     ControllerEmu::ControlGroup* wmShake = wm->GetWiimoteGroup(WiimoteGroup::Shake);
     ControllerEmu::ControlGroup* wmTilt = wm->GetWiimoteGroup(WiimoteGroup::Tilt);
-#if 0
-    ControllerEmu::ControlGroup* wmSwing = wm->GetWiimoteGroup(WiimoteGroup::Swing);
-#endif
-    ControllerEmu::ControlGroup* wmHotkeys = wm->GetWiimoteGroup(WiimoteGroup::Hotkeys);
-//#endif
 
-    const int irMode = Libretro::Options::GetCached<int>(Libretro::Options::wiimote::IR_MODE);
-    const int irCenter = Libretro::Options::GetCached<int>(Libretro::Options::wiimote::IR_OFFSET);
-    const int irWidth = Libretro::Options::GetCached<int>(Libretro::Options::wiimote::IR_YAW);
-    const int irHeight = Libretro::Options::GetCached<int>(Libretro::Options::wiimote::IR_PITCH);
-
-    static_cast<ControllerEmu::NumericSetting<double>*>(wmIR->numeric_settings[1].get())
-      ->SetValue(irCenter); // IR Vertical Offset
-    static_cast<ControllerEmu::NumericSetting<double>*>(wmIR->numeric_settings[2].get())
-      ->SetValue(irWidth);  // IR Total Yaw
-    static_cast<ControllerEmu::NumericSetting<double>*>(wmIR->numeric_settings[3].get())
-      ->SetValue(irHeight); // IR Total Pitch
+    f.irOffset = true;
+    f.irYaw = true;
+    f.irPitch = true;
+    f.irDeadzone = true;
+    f.swingAngle = true;
 
     if (device == RETRO_DEVICE_WIIMOTE_NC)
     {
@@ -1024,13 +1302,7 @@ void retro_set_controller_port_device_wii(unsigned port, unsigned device)
       wmButtons->SetControlExpression(4, "L");                             // -
       wmButtons->SetControlExpression(5, "R");                             // +
 
-      if (irMode != 0 && irMode != 1)
-      {
-        wmTilt->SetControlExpression(0, "`" + devAnalog + ":Y1-`");  // Forward
-        wmTilt->SetControlExpression(1, "`" + devAnalog + ":Y1+`");  // Backward
-        wmTilt->SetControlExpression(2, "`" + devAnalog + ":X1-`");  // Left
-        wmTilt->SetControlExpression(3, "`" + devAnalog + ":X1+`");  // Right
-      }
+      f.irMode = true;
     }
     else
     {
@@ -1107,44 +1379,16 @@ void retro_set_controller_port_device_wii(unsigned port, unsigned device)
     wmDPad->SetControlExpression(2, "Left");   // Left
     wmDPad->SetControlExpression(3, "Right");  // Right
 
-    if (irMode == 0 || irMode == 1)
-    {
-      // Set right stick to control the IR
-      wmIR->SetControlExpression(0, "`" + devAnalog + ":Y1-`");     // Up
-      wmIR->SetControlExpression(1, "`" + devAnalog + ":Y1+`");     // Down
-      wmIR->SetControlExpression(2, "`" + devAnalog + ":X1-`");     // Left
-      wmIR->SetControlExpression(3, "`" + devAnalog + ":X1+`");     // Right
-      static_cast<ControllerEmu::NumericSetting<bool>*>(wmIR->numeric_settings[4].get())
-        ->SetValue(irMode == 0);                                    // Relative input
-      static_cast<ControllerEmu::NumericSetting<bool>*>(wmIR->numeric_settings[5].get())
-        ->SetValue(true);                                           // Auto hide
-    }
-    else
-    {
-      // Mouse controls IR
-      wmIR->SetControlExpression(0, "`" + devPointer + ":Y0-`");    // Up
-      wmIR->SetControlExpression(1, "`" + devPointer + ":Y0+`");    // Down
-      wmIR->SetControlExpression(2, "`" + devPointer + ":X0-`");    // Left
-      wmIR->SetControlExpression(3, "`" + devPointer + ":X0+`");    // Right
-      static_cast<ControllerEmu::NumericSetting<bool>*>(wmIR->numeric_settings[4].get())
-        ->SetValue(false);                                          // Relative input
-      static_cast<ControllerEmu::NumericSetting<bool>*>(wmIR->numeric_settings[5].get())
-        ->SetValue(false);                                          // Auto hide
-    }
+    f.irModifier = true;
+    f.swingModifier = true;
+    f.sideways = true;
+    Libretro::Input::UpdateWiimoteMappings(f, port, device);
 
     wmShake->SetControlExpression(0, "R2 | `" + devMouse + ":Middle`");  // Wiimote shake X
     wmShake->SetControlExpression(1, "R2 | `" + devMouse + ":Middle`");  // Wiimote shake Y
     wmShake->SetControlExpression(2, "R2 | `" + devMouse + ":Middle`");  // Wiimote shake Z
-
-    wmHotkeys->SetControlExpression(0, "L3");  // Sideways Toggle
-#if 0
-    wmHotkeys->SetControlExpression(1, "");  // Upright Toggle
-    wmHotkeys->SetControlExpression(2, "");  // Sideways Hold
-    wmHotkeys->SetControlExpression(3, "");  // Upright Hold
-#endif
   }
 
-  ControllerEmu::ControlGroup* wmRumble = wm->GetWiimoteGroup(WiimoteGroup::Rumble);
   ControllerEmu::ControlGroup* wmOptions = wm->GetWiimoteGroup(WiimoteGroup::Options);
   ControllerEmu::Attachments* wmExtension =
       (ControllerEmu::Attachments*)wm->GetWiimoteGroup(WiimoteGroup::Attachments);
@@ -1158,6 +1402,7 @@ void retro_set_controller_port_device_wii(unsigned port, unsigned device)
   static_cast<ControllerEmu::NumericSetting<bool>*>(wmOptions->numeric_settings[3].get())
       ->SetValue(false);  // Sideways Wiimote
 
+  ControllerEmu::ControlGroup* wmRumble = wm->GetWiimoteGroup(WiimoteEmu::WiimoteGroup::Rumble);
   bool enableRumble = Libretro::Options::GetCached<bool>(Libretro::Options::sysconf::ENABLE_RUMBLE);
   if (enableRumble)
     wmRumble->SetControlExpression(0, "Rumble");
@@ -1200,5 +1445,7 @@ void retro_set_controller_port_device_wii(unsigned port, unsigned device)
   }
 
   wm->UpdateReferences(g_controller_interface);
-  ::Wiimote::GetConfig()->SaveConfig();
+  bool saveOrLoad = Libretro::Options::GetCached<bool>(Libretro::Options::wiimote::SAVE_LOAD_SETTINGS);
+  if (!saveOrLoad)
+    ::Wiimote::GetConfig()->SaveConfig();
 }

--- a/Source/Core/DolphinLibretro/Input.h
+++ b/Source/Core/DolphinLibretro/Input.h
@@ -6,6 +6,28 @@
 // only 4 support sensors, but the array may be upto 8 if connected GC controllers
 #define NUM_CONTROLLERS_FOR_SENSORS 8
 
+struct WiimoteUpdateFlags
+{
+    bool irMode        = false;
+    bool irOffset      = false; // center
+    bool irYaw         = false; // width
+    bool irPitch       = false; // height
+    bool irDeadzone    = false;
+    bool irModifier    = false;
+    bool swingModifier = false;
+    bool swingAngle    = false;
+    bool sideways      = false;
+    bool rumble        = false;
+
+    bool any() const {
+        return irMode || irOffset || irYaw || irPitch ||
+               irDeadzone || irModifier || swingModifier ||
+               swingAngle || sideways || rumble;
+    }
+};
+
+void refresh_all_wiimote_flags(unsigned port, unsigned device);
+
 namespace Libretro
 {
 namespace Input
@@ -24,8 +46,9 @@ void UpdateAccelerometer(unsigned port);
 void UpdateGyro(unsigned port);
 void Update();
 void Shutdown();
-void ResetControllers();
+void ResetControllers(const WiimoteUpdateFlags& f);
 void BluetoothPassthroughBind();
+void UpdateWiimoteMappings(const WiimoteUpdateFlags& f, unsigned port, unsigned device);
 } // namespace Input
 } // namespace Libretro
 

--- a/Source/Core/DolphinLibretro/Input.h
+++ b/Source/Core/DolphinLibretro/Input.h
@@ -3,15 +3,119 @@
 #include <libretro.h>
 #include "Common/WindowSystemInfo.h"
 
+// only 4 support sensors, but the array may be upto 8 if connected GC controllers
+#define NUM_CONTROLLERS_FOR_SENSORS 8
+
 namespace Libretro
 {
 namespace Input
 {
+constexpr std::string_view source = "Libretro";
+extern double g_accel_pos[NUM_CONTROLLERS_FOR_SENSORS][3];
+extern double g_accel_neg[NUM_CONTROLLERS_FOR_SENSORS][3];
+extern double g_gyro[NUM_CONTROLLERS_FOR_SENSORS][3];
+
+static retro_sensor_interface sensor_interface = {0};
+
 void Init(const WindowSystemInfo& wsi);
 void InitStage2();
+void InitSensors();
+void UpdateAccelerometer(unsigned port);
+void UpdateGyro(unsigned port);
 void Update();
 void Shutdown();
 void ResetControllers();
 void BluetoothPassthroughBind();
-}
-}
+} // namespace Input
+} // namespace Libretro
+
+class SensorDevice : public ciface::Core::Device
+{
+public:
+  explicit SensorDevice(unsigned port) : m_port(port) {}
+
+  std::string GetName() const override { return "Sensor"; }
+  std::string GetSource() const override { return std::string(Libretro::Input::source); }
+  unsigned int GetPort() const { return m_port; }
+  ciface::Core::DeviceRemoval UpdateInput() override { return ciface::Core::DeviceRemoval::Keep; }
+
+private:
+  class ScalarInput : public ciface::Core::Device::Input
+  {
+  public:
+    ScalarInput(const char* name, const double* slot) : m_name(name), m_slot(slot) {}
+    std::string GetName() const override { return m_name; }
+    ControlState GetState() const override { return *m_slot; }
+  private:
+    const char* m_name;
+    const double* m_slot;
+  };
+
+public:
+  void RegisterAll()
+  {
+    AddInput(new ScalarInput("GyroX",  &Libretro::Input::g_gyro[m_port][0]));
+    AddInput(new ScalarInput("GyroY",  &Libretro::Input::g_gyro[m_port][1]));
+    AddInput(new ScalarInput("GyroZ",  &Libretro::Input::g_gyro[m_port][2]));
+    AddInput(new ScalarInput("AccelX+", &Libretro::Input::g_accel_pos[m_port][0]));
+    AddInput(new ScalarInput("AccelX-", &Libretro::Input::g_accel_neg[m_port][0]));
+    AddInput(new ScalarInput("AccelY+", &Libretro::Input::g_accel_pos[m_port][1]));
+    AddInput(new ScalarInput("AccelY-", &Libretro::Input::g_accel_neg[m_port][1]));
+    AddInput(new ScalarInput("AccelZ+", &Libretro::Input::g_accel_pos[m_port][2]));
+    AddInput(new ScalarInput("AccelZ-", &Libretro::Input::g_accel_neg[m_port][2]));
+  }
+
+private:
+  unsigned m_port;
+};
+
+class GyroDevice : public ciface::Core::Device
+{
+private:
+  class GyroAxis : public ciface::Core::Device::Input
+  {
+  public:
+    enum Axis { PITCH, ROLL, YAW };
+
+    GyroAxis(unsigned port, Axis axis, const char* name)
+        : m_port(port), m_axis(axis), m_name(name) {}
+
+    std::string GetName() const override { return m_name; }
+
+    ControlState GetState() const override
+    {
+      if (!Libretro::Input::sensor_interface.get_sensor_input)
+        return 0.0;
+
+      switch (m_axis)
+      {
+      case PITCH:
+        return Libretro::Input::sensor_interface.get_sensor_input(m_port, RETRO_SENSOR_GYROSCOPE_Y);
+      case ROLL:
+        return Libretro::Input::sensor_interface.get_sensor_input(m_port, RETRO_SENSOR_GYROSCOPE_X);
+      case YAW:
+        return Libretro::Input::sensor_interface.get_sensor_input(m_port, RETRO_SENSOR_GYROSCOPE_Z);
+      }
+      return 0.0;
+    }
+
+  private:
+    const unsigned m_port;
+    const Axis m_axis;
+    const char* m_name;
+  };
+
+public:
+  GyroDevice(unsigned port) : m_port(port)
+  {
+    AddInput(new GyroAxis(port, GyroAxis::PITCH, "Pitch"));
+    AddInput(new GyroAxis(port, GyroAxis::ROLL, "Roll"));
+    AddInput(new GyroAxis(port, GyroAxis::YAW, "Yaw"));
+  }
+
+  std::string GetName() const override { return "Gyroscope"; }
+  std::string GetSource() const override { return std::string(Libretro::Input::source); }
+
+private:
+  unsigned m_port;
+};

--- a/Source/Core/DolphinLibretro/Main.cpp
+++ b/Source/Core/DolphinLibretro/Main.cpp
@@ -157,6 +157,7 @@ void retro_reset(void)
 
 void retro_run(void)
 {
+  Libretro::Input::InitSensors();
   Libretro::Options::CheckForUpdatedVariables();
   Libretro::FrameTiming::CheckForFastForwarding();
 #if defined(_DEBUG)

--- a/Source/Core/DolphinLibretro/Main.cpp
+++ b/Source/Core/DolphinLibretro/Main.cpp
@@ -282,14 +282,20 @@ void retro_run(void)
     Libretro::environ_cb(RETRO_ENVIRONMENT_SET_GEOMETRY, &info);
   }
 
-  if (Libretro::Options::IsUpdated(Libretro::Options::wiimote::IR_MODE) ||
-      Libretro::Options::IsUpdated(Libretro::Options::wiimote::IR_OFFSET) ||
-      Libretro::Options::IsUpdated(Libretro::Options::wiimote::IR_YAW) ||
-      Libretro::Options::IsUpdated(Libretro::Options::wiimote::IR_PITCH) ||
-      Libretro::Options::IsUpdated(Libretro::Options::sysconf::ENABLE_RUMBLE))
-  {
-    Libretro::Input::ResetControllers();
-  }
+  WiimoteUpdateFlags flags;
+  flags.irMode  = Libretro::Options::IsUpdated(Libretro::Options::wiimote::IR_MODE);
+  flags.irOffset = Libretro::Options::IsUpdated(Libretro::Options::wiimote::IR_OFFSET);
+  flags.irYaw = Libretro::Options::IsUpdated(Libretro::Options::wiimote::IR_YAW);
+  flags.irPitch = Libretro::Options::IsUpdated(Libretro::Options::wiimote::IR_PITCH);
+  flags.irDeadzone = Libretro::Options::IsUpdated(Libretro::Options::wiimote::IR_DEADZONE);
+  flags.irModifier = Libretro::Options::IsUpdated(Libretro::Options::wiimote::IR_MODIFIER);
+  flags.swingModifier = Libretro::Options::IsUpdated(Libretro::Options::wiimote::SWING_MODIFIER);
+  flags.swingAngle = Libretro::Options::IsUpdated(Libretro::Options::wiimote::SWING_ANGLE);
+  flags.sideways = Libretro::Options::IsUpdated(Libretro::Options::wiimote::HOTKEY_SIDEWAYS_TOGGLE);
+  flags.rumble = Libretro::Options::IsUpdated(Libretro::Options::sysconf::ENABLE_RUMBLE);
+
+  if (flags.any())
+    Libretro::Input::ResetControllers(flags);
 
   if (Libretro::Options::IsUpdated(Libretro::Options::sysconf::WIIMOTE_CONTINUOUS_SCANNING))
   {

--- a/Source/Core/VideoCommon/Resources/CustomResourceManager.cpp
+++ b/Source/Core/VideoCommon/Resources/CustomResourceManager.cpp
@@ -38,10 +38,18 @@ void CustomResourceManager::Shutdown()
 
   m_asset_cache.Shutdown();
   m_worker_thread.Shutdown();
+#ifdef __LIBRETRO__
+  Reset(true);
+#else
   Reset();
+#endif
 }
 
+#ifdef __LIBRETRO__
+void CustomResourceManager::Reset(bool isShutdown)
+#else
 void CustomResourceManager::Reset()
+#endif
 {
   m_material_resources.clear();
   m_shader_resources.clear();
@@ -55,6 +63,12 @@ void CustomResourceManager::Reset()
 
   m_asset_cache.Reset();
   m_texture_pool.Reset();
+
+#ifdef __LIBRETRO__
+  if (isShutdown)
+    m_worker_thread.Shutdown();
+  else
+#endif
   m_worker_thread.Reset("resource-worker");
 }
 

--- a/Source/Core/VideoCommon/Resources/CustomResourceManager.h
+++ b/Source/Core/VideoCommon/Resources/CustomResourceManager.h
@@ -26,7 +26,11 @@ public:
   void Initialize();
   void Shutdown();
 
+#ifdef __LIBRETRO__
+  void Reset(bool isShutdown = false);
+#else
   void Reset();
+#endif
 
   // Request that an asset be reloaded
   void MarkAssetDirty(const CustomAssetLibrary::AssetID& asset_id);


### PR DESCRIPTION
Patch notes:

**1. Adds accelerometer / gyros from retroarch to be used for motion controls in dolphin**

This means you can now connect a Wiimote via standard bluetooth and use the libretro sensor API instead to make use of motion controls.

You can still use dolphin bar via Real Wiimote OR passthrough bluetooth mode without this if you prefer that method.

Gyro(s) are implemented but not tested as I don't own a MotionPlus controller.

Tested with retroarch (using udev sensors and sdl2 sensors) - requires compilation of RetroArch master (or a nightly starting from March 9, 2026). If the sensors do not work you should try using the retropad core to make sure things are working on your system.

Using Mario Kart Wii - allows you to turn and Wii Sports (tennis tested - allows you to swing)!

Tested under Linux.

**2. Also adds a shutdown fix** for mingw on windows. https://github.com/libretro/dolphin/issues/412. This is a bug in standalone, it recreates threads on shutdown, which isn't exposed normally with MSVC that is used. But we use MINGW, and that exposes this bug.

**3. Now adds the ability to load and prevent overwriting of WiiMote/GCPad configs**. This is turned off by default. It is under Wii mote / Gyro / Swing - Load settings OFF/ON. This is for people who wish to use custom INIs.

**4. Sideways toggle can now be set by the user**. Found under WiiMote Sideways > Toggle Button. Defaults to OFF. Recommended button - L3 as this is unused.

**5. IR modifier and Swing modifier buttons**. 

This allows the user to pick which buttons to are used in addition to right thumbstick to control IR control or swing control.

Default is no modifier for IR control.

Example usage: Zelda, you can change the  IR modifier (to L3) which then frees up the right thumb stick to be used for swinging by setting the swing modifier to 'None'. You can still look around in Zelda but being able to swing still.

Fixes: https://github.com/libretro/dolphin/issues/406

**6. Also adds swing angle and IR Deadzone options.**