### PR TITLE
libretro: aspect ratio update in real time, set FPS correctly

### DIFF
--- a/Source/Core/DolphinLibretro/Audio.cpp
+++ b/Source/Core/DolphinLibretro/Audio.cpp
@@ -126,8 +126,9 @@ void Init()
 
 inline unsigned GetSamplesForFrame(unsigned sample_rate)
 {
-  double frame_time_sec = FrameTiming::target_frame_duration_usec.load(std::memory_order_relaxed) * 1e-6;
-  return std::clamp(static_cast<unsigned>(frame_time_sec * sample_rate),
+  double frame_time_sec =
+      FrameTiming::target_frame_duration_usec.load(std::memory_order_relaxed) * 1e-6;
+  return std::clamp(static_cast<unsigned>(std::lround(frame_time_sec * sample_rate)),
                     MIN_SAMPLES, MAX_SAMPLES);
 }
 
@@ -230,10 +231,18 @@ void Stream::PushAudioForFrame()
   }
   else
   {
-    if (retro_get_region() == RETRO_REGION_NTSC)
-      samples_for_frame = m_sample_rate / 60;
+    if (Libretro::g_core_refresh_rate <= 0.0)
+    {
+      if (retro_get_region() == RETRO_REGION_NTSC)
+        samples_for_frame = m_sample_rate / 60;
+      else
+        samples_for_frame = m_sample_rate / 50;
+    }
     else
-      samples_for_frame = m_sample_rate / 50;
+    {
+      samples_for_frame =
+        static_cast<unsigned>(std::lround(m_sample_rate / Libretro::g_core_refresh_rate));
+    }
   }
   
   samples_for_frame = std::clamp(samples_for_frame, MIN_SAMPLES, MAX_SAMPLES);

--- a/Source/Core/DolphinLibretro/Audio.h
+++ b/Source/Core/DolphinLibretro/Audio.h
@@ -8,6 +8,7 @@
 
 namespace Libretro
 {
+extern double g_core_refresh_rate;
 namespace Audio
 {
 extern retro_audio_sample_batch_t batch_cb;

--- a/Source/Core/DolphinLibretro/Main.cpp
+++ b/Source/Core/DolphinLibretro/Main.cpp
@@ -13,6 +13,7 @@
 #include "Common/scmrev.h"
 #include "Common/Version.h"
 #include "Core/BootManager.h"
+#include "Core/Config/GraphicsSettings.h"
 #include "Core/Config/MainSettings.h"
 #include "Core/Config/SYSCONFSettings.h"
 #include "Core/ConfigManager.h"
@@ -301,6 +302,15 @@ void retro_run(void)
 
   if (flags.any())
     Libretro::Input::ResetControllers(flags);
+
+  if (Libretro::Options::IsUpdated(Libretro::Options::gfx_settings::ASPECT_RATIO))
+    Config::SetCurrent(
+      Config::GFX_ASPECT_RATIO, static_cast<AspectMode>(
+        Libretro::GetOption<int>(
+          Libretro::Options::gfx_settings::ASPECT_RATIO, static_cast<int>(AspectMode::Stretch)
+        )
+      )
+    );
 
   if (Libretro::Options::IsUpdated(Libretro::Options::sysconf::WII_SPEAK_MUTED))
     Config::SetCurrent(Config::MAIN_WII_SPEAK_MUTED,

--- a/Source/Core/DolphinLibretro/Main.cpp
+++ b/Source/Core/DolphinLibretro/Main.cpp
@@ -67,6 +67,7 @@ namespace Libretro
 {
 extern retro_environment_t environ_cb;
 static bool widescreen;
+double g_core_refresh_rate{0};
 }  // namespace Libretro
 
 extern "C" {
@@ -151,7 +152,12 @@ void retro_get_system_av_info(retro_system_av_info* info)
     Libretro::widescreen = Config::Get(Config::SYSCONF_WIDESCREEN);
 
   info->geometry.aspect_ratio = Libretro::widescreen ? 16.0 / 9.0 : 4.0 / 3.0;
-  info->timing.fps = (retro_get_region() == RETRO_REGION_NTSC) ? (60.0f / 1.001f) : 50.0f;
+
+  Core::System& system = Core::System::GetInstance();
+  double fps = system.GetVideoInterface().GetTargetRefreshRate();
+  if (fps <= 0.0)
+    fps = (retro_get_region() == RETRO_REGION_NTSC) ? (60.0 / 1.001) : 50.0;
+  info->timing.fps = fps;
   info->timing.sample_rate = Libretro::Audio::GetActiveSampleRate();
 }
 
@@ -225,6 +231,8 @@ void retro_run(void)
     while (!Core::IsRunningOrStarting(Core::System::GetInstance()))
       Common::SleepCurrentThread(100);
 
+    Libretro::g_core_refresh_rate = system.GetVideoInterface().GetTargetRefreshRate();
+
     // Expose memory layout to RetroArch for RetroAchievements.
     // rcheevos matches descriptors by real_address from its console region
     // definitions: GameCube MEM1 at 0x80000000, Wii MEM2 at 0x90000000.
@@ -285,6 +293,18 @@ void retro_run(void)
     retro_system_av_info info;
     retro_get_system_av_info(&info);
     Libretro::environ_cb(RETRO_ENVIRONMENT_SET_GEOMETRY, &info);
+  }
+
+  // target refresh rate has changed - e.g. user has chosen 60 Hz for a PAL game
+  double new_rate = system.GetVideoInterface().GetTargetRefreshRate();
+
+  if (round(Libretro::g_core_refresh_rate * 1e6) != round(new_rate * 1e6))
+  {
+    Libretro::g_core_refresh_rate = new_rate;
+
+    retro_system_av_info info;
+    retro_get_system_av_info(&info);
+    Libretro::environ_cb(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &info);
   }
 
   WiimoteUpdateFlags flags;
@@ -434,7 +454,7 @@ bool retro_unserialize(const void* data, size_t size)
   return true;
 }
 
-unsigned retro_get_region(void)
+unsigned retro_get_region()
 {
   Core::System& system = Core::System::GetInstance();
 


### PR DESCRIPTION
1. Just allows changing aspect ratio while emulation is running like standalone does
2. Set correct FPS for PAL titles when user chooses 50Hz or 60Hz

Fixes: https://github.com/libretro/dolphin/issues/397