### PR TITLE
eject disc when calling retro_set_eject_state(1)

### DIFF
--- a/Source/Core/DolphinLibretro/Boot.cpp
+++ b/Source/Core/DolphinLibretro/Boot.cpp
@@ -665,17 +665,18 @@ static bool retro_set_eject_state(bool ejected)
 
   eject_state = ejected;
 
-  if (!ejected)
-  {
-    if (disk_index < disk_paths.size())
+  Core::RunOnCPUThread(Core::System::GetInstance(), [ejected] {
+    auto& system = Core::System::GetInstance();
+    Core::CPUThreadGuard guard{system};
+
+    if (ejected)
+      system.GetDVDInterface().EjectDisc(guard, DVD::EjectCause::User);
+    else if (disk_index < disk_paths.size())
     {
-      Core::RunOnCPUThread(Core::System::GetInstance(), [] {
-        Core::CPUThreadGuard guard{Core::System::GetInstance()};
-        const std::string path = NormalizePath(disk_paths[disk_index]);
-        Core::System::GetInstance().GetDVDInterface().ChangeDisc(guard, path);
-      }, true);  // wait_for_completion = true
+      const std::string path = NormalizePath(disk_paths[disk_index]);
+      system.GetDVDInterface().ChangeDisc(guard, path);
     }
-  }
+  }, true); // wait_for_completion = true
 
   return true;
 }


### PR DESCRIPTION
Notifies Dolphin of a disc eject if the user calls `retro_set_eject_state` with no further action. Only tested on my own frontend.

<img width="837" height="687" alt="image" src="https://github.com/user-attachments/assets/78ee8f70-18fe-42af-aab7-e1168c609dd3" />
