### PR TITLE
Fix macOS save state crash in dual-core mode

### DIFF
--- a/Source/Core/DolphinLibretro/Main.cpp
+++ b/Source/Core/DolphinLibretro/Main.cpp
@@ -489,17 +489,24 @@ bool retro_serialize(void* data, size_t size)
   if (system.IsDualCoreMode())
     ar->SetPassthrough(true);
 
-  Core::RunOnCPUThread(Core::System::GetInstance(), [&] {
+  const bool was_cpu = Core::IsCPUThread();
+  if (!was_cpu)
+    Core::DeclareAsCPUThread();
 
+  Core::RunOnCPUThread(Core::System::GetInstance(), [&] {
     PointerWrap p((u8**)&data, size, PointerWrap::Mode::Write);
     State::DoState(Core::System::GetInstance(), p);
   }, true);
+
+  if (!was_cpu)
+    Core::UndeclareAsCPUThread();
 
   if (system.IsDualCoreMode())
     ar->SetPassthrough(false);
 
   return true;
 }
+
 bool retro_unserialize(const void* data, size_t size)
 {
   Core::System& system = Core::System::GetInstance();
@@ -508,10 +515,17 @@ bool retro_unserialize(const void* data, size_t size)
   if (system.IsDualCoreMode())
     ar->SetPassthrough(true);
 
+  const bool was_cpu = Core::IsCPUThread();
+  if (!was_cpu)
+    Core::DeclareAsCPUThread();
+
   Core::RunOnCPUThread(Core::System::GetInstance(), [&] {
     PointerWrap p((u8**)&data, size, PointerWrap::Mode::Read);
     State::DoState(Core::System::GetInstance(), p);
   }, true);
+
+  if (!was_cpu)
+    Core::UndeclareAsCPUThread();
 
   if (system.IsDualCoreMode())
     ar->SetPassthrough(false);


### PR DESCRIPTION
In dual-core mode on macOS, `retro_serialize` and `retro_unserialize` queue `DoState` to the CPU thread via `RunOnCPUThread`. Frontends using an offscreen CGL context (no window-backed default framebuffer) set the GL context current on the calling thread, not the CPU thread. Any GL calls during `DoState` on the CPU thread segfault.

This temporarily declares the calling thread as the CPU thread so `DoState` runs inline where the GL context is valid.

Only tested on macOS arm64 with my own libretro frontend using an offscreen CGL context.