### PR TITLE
Added the core option: Disc Based Games Boot to Wii Menu.

### DIFF
--- a/Source/Core/DolphinLibretro/Boot.cpp
+++ b/Source/Core/DolphinLibretro/Boot.cpp
@@ -6,6 +6,7 @@
 #include <fstream>
 
 #include "Common/CommonPaths.h"
+#include "Core/CommonTitles.h"
 #include "Common/FileUtil.h"
 #include "Common/Version.h"
 #include "Core/Boot/Boot.h"
@@ -571,8 +572,34 @@ bool retro_load_game(const struct retro_game_info* game)
       Libretro::GetOption<bool>(sysconf::WII_LOGI_MICROPHONE_ENABLE, /*def=*/false));
   }
 
-  if (!BootManager::BootCore(Core::System::GetInstance(),
-                             BootParameters::GenerateFromFile(normalized_game_paths), wsi))
+  const bool disc_based_games_boot_to_wii_menu = Libretro::GetOption<bool>(Libretro::Options::core::DISC_BASED_GAMES_BOOT_TO_WII_MENU, false);
+  std::unique_ptr<BootParameters> boot_params = BootParameters::GenerateFromFile(normalized_game_paths);
+
+  if (disc_based_games_boot_to_wii_menu)
+  {
+    bool is_disc_title = false;
+    if (!normalized_game_paths.empty())
+    {
+      auto volume = DiscIO::CreateDisc(normalized_game_paths.front());
+      if (volume && (volume->GetVolumeType() == DiscIO::Platform::WiiDisc || volume->GetVolumeType() == DiscIO::Platform::GameCubeDisc))
+        is_disc_title = true;
+      else
+        WARN_LOG_FMT(BOOT, "'Disc Based Games Boot to Wii System Menu' enabled but content is not a disc based game, ignoring Wii Menu");
+    }
+
+    const std::string wii_menu_tmd_file_name = Common::GetTMDFileName(Titles::SYSTEM_MENU, Common::FromWhichRoot::Configured);
+    const bool wii_menu_installed = File::Exists(wii_menu_tmd_file_name);
+    if (is_disc_title && !wii_menu_installed)
+      WARN_LOG_FMT(BOOT,"'Disc Based Games Boot to Wii System Menu' enabled but Wii Menu not found at save location: {}, booting directly instead", wii_menu_tmd_file_name);
+
+    if (is_disc_title && wii_menu_installed)
+    {
+      Config::SetBase(Config::MAIN_DEFAULT_ISO, normalized_game_paths.front());
+      boot_params = std::make_unique<BootParameters>(BootParameters::NANDTitle{Titles::SYSTEM_MENU});
+    }
+  }
+
+  if (!BootManager::BootCore(Core::System::GetInstance(), std::move(boot_params), wsi))
   {
     ERROR_LOG_FMT(BOOT, "Could not boot {}", game->path);
     return false;

--- a/Source/Core/DolphinLibretro/Common/Options.cpp
+++ b/Source/Core/DolphinLibretro/Common/Options.cpp
@@ -260,6 +260,21 @@ static struct retro_core_option_v2_definition option_defs[] = {
     "enabled"
   },
   {
+    Libretro::Options::core::DISC_BASED_GAMES_BOOT_TO_WII_MENU,
+    "Core > Disc Based Games Boot to Wii Menu",
+    "Disc Based Games Boot to Wii System Menu",
+    "When a Wii System Menu is installed in the save location and the game is a disc based game, it will start the Wii Menu with the disc inserted in the drive instead of directly booting the game. "
+    "Beware: The game region must match the Wii Menu region otherwise the game will not be recognized.",
+    nullptr,
+    CATEGORY_CORE,
+    {
+      {"disabled", nullptr},
+      {"enabled", nullptr},
+      {nullptr, nullptr}
+    },
+    "disabled"
+  },
+  {
     Libretro::Options::core::LANGUAGE,
     "Core > System Language",
     "System Language",

--- a/Source/Core/DolphinLibretro/Common/Options.h
+++ b/Source/Core/DolphinLibretro/Common/Options.h
@@ -129,6 +129,7 @@ namespace core {
   constexpr const char CHEATS_ENABLED[] = "dolphin_cheats_enabled";
   constexpr const char CHEATS_IMPORT[] = "dolphin_cheats_import";
   constexpr const char SKIP_GC_BIOS[] = "dolphin_skip_gc_bios";
+  constexpr const char DISC_BASED_GAMES_BOOT_TO_WII_MENU[] = "dolphin_disc_based_games_boot_to_wii_menu";
   constexpr const char LANGUAGE[] = "dolphin_language";
   constexpr const char FAST_DISC_SPEED[] = "dolphin_fast_disc_speed";
   constexpr const char MAIN_MMU[] = "dolphin_main_mmu";


### PR DESCRIPTION
The standalone emulator has the option to boot to the Wii Menu with the game disc in the tray, if the Wii Menu has been installed, with the following CLI arguments: dolphin.exe -b -n 0000000100000002 -C Dolphin.Core.DefaultISO=<path_to_game>.
It can also be done from the GUI by right-clicking a disc based game and selecting the option: Set as Default ISO and then launching the Wii Menu.

The retroarch core lacks this functionality currently and with this option, it is being brought over. Do note that the Wii Menu must be installed to the save location for this to work, just like with the standalone emulator.

The code simply checks if the option is enabled and if that is the case, it checks:

- If the game is a Gamecube or a Wii disc game.
- If the Wii Menu is installed in the save location.

If both checks succeed, the disc is set as the default iso and the Wii Menu is launched. If either check fails, the game is booted as if the option is not enabled.

In the description of the option, there is a note that the game must match the same region as the Wii Menu installed, otherwise the game will not be recognized. This is not a limitation of the implementation but a limitation of the Wii Menu as it reïnstates region locking: https://wiki.dolphin-emu.org/index.php?title=Wii_Menu

"Alternate Region Titles

The Wii Menu will only load titles corresponding to its region. This region locking is enforced by the Wii Menu itself. Use an appropriately aligned version or load alternate region titles via the Game List. "

It has been tested on Wii Menu: 4.3U, 4.3E, 4.3J, 4.3K.
