### PR TITLE
libretro: use ANDROID_NDK_NEXT instead of hard coding ndk

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -99,7 +99,7 @@ android-arm64-v8a:
     - .libretro-android-cmake-arm64-v8a
     - .core-defs
   variables:
-    ANDROID_NDK_VERSION: 26.2.11394342
+    ANDROID_NDK_VERSION: $ANDROID_NDK_NEXT
     NDK_ROOT: /android-sdk-linux/ndk/$ANDROID_NDK_VERSION
 
 # iOS arm64


### PR DESCRIPTION
Removes the hard coded version, and uses the variable from the docker instead so it can be updated easier.