### PR TITLE
Subsystem implementation for the Game Boy Player.

### DIFF
--- a/Source/Core/Core/HW/GBACore.cpp
+++ b/Source/Core/Core/HW/GBACore.cpp
@@ -758,7 +758,14 @@ bool Core::GetRomInfo(const char* rom_path, std::array<u8, 20>& hash, std::strin
 
 std::string Core::GetSavePath(std::string_view rom_path, int device_number)
 {
+  // This is done to make the save file compatible with the save from the mGBA core in RA as it
+  // saves in *.srm format.
+#ifdef __LIBRETRO__
   std::string save_path = fmt::format("{}.srm", rom_path.substr(0, rom_path.find_last_of('.')));
+#else
+  std::string save_path =
+      fmt::format("{}-{}.sav", rom_path.substr(0, rom_path.find_last_of('.')), device_number + 1);
+#endif
 
   if (!Config::Get(Config::MAIN_GBA_SAVES_IN_ROM_PATH))
   {

--- a/Source/Core/Core/HW/GBACore.cpp
+++ b/Source/Core/Core/HW/GBACore.cpp
@@ -758,8 +758,7 @@ bool Core::GetRomInfo(const char* rom_path, std::array<u8, 20>& hash, std::strin
 
 std::string Core::GetSavePath(std::string_view rom_path, int device_number)
 {
-  std::string save_path =
-      fmt::format("{}-{}.sav", rom_path.substr(0, rom_path.find_last_of('.')), device_number + 1);
+  std::string save_path = fmt::format("{}.srm", rom_path.substr(0, rom_path.find_last_of('.')));
 
   if (!Config::Get(Config::MAIN_GBA_SAVES_IN_ROM_PATH))
   {

--- a/Source/Core/DolphinLibretro/Boot.cpp
+++ b/Source/Core/DolphinLibretro/Boot.cpp
@@ -8,6 +8,7 @@
 #include "Common/CommonPaths.h"
 #include "Core/CommonTitles.h"
 #include "Common/FileUtil.h"
+#include "Common/StringUtil.h"
 #include "Common/Version.h"
 #include "Core/Boot/Boot.h"
 #include "Core/BootManager.h"
@@ -19,6 +20,7 @@
 #include "Core/GeckoCodeConfig.h"
 #include "Core/HW/DVD/DVDInterface.h"
 #include "Core/HW/EXI/EXI_Device.h"
+#include "Core/HW/HSP/HSP_Device.h"
 #include "Core/HW/VideoInterface.h"
 #include "Core/HW/WiimoteReal/WiimoteReal.h"
 #include "Core/PowerPC/PowerPC.h"
@@ -52,6 +54,10 @@ static void InitDiskControlInterface();
 static unsigned disk_index = 0;
 static bool eject_state;
 static std::vector<std::string> disk_paths;
+
+// GBPlayer
+static std::string GBPlayer_rom_path;
+static bool GBPlayer_active;
 
 // silence forward declaration warnings
 void reload_cheats_from_ini();
@@ -168,12 +174,64 @@ void generate_cht_from_ini(std::string fileName)
 bool retro_load_game(const struct retro_game_info* game)
 {
   const char* save_dir = NULL;
+  const char* gba_save_dir = NULL;
   const char* system_dir = NULL;
   const char* core_assets_dir = NULL;
+  std::string rebuild_save_dir;
   std::string user_dir;
   std::string sys_dir;
 
-  Libretro::environ_cb(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY, &save_dir);
+  /*
+   *  If the GBPlayer is active, we try to reconstruct the GC save dir location
+   *  with regards to content sorting and core sorting. If we do not do this,
+   *  there will be a User directory with GC saves in the GB/GBC/GBA rom save path
+   *  when a user has content/core sorting enabled. Since the user is trying to avoid
+   *  said behavior actively if those sorting options are enabled,
+   *  we should seperate them accordingly.
+   */
+  if (Libretro::GBPlayer_active)
+  {
+    std::filesystem::path gba_content_dir = std::filesystem::path("");
+    if (!Libretro::GBPlayer_rom_path.empty())
+      gba_content_dir = std::filesystem::path(Libretro::GBPlayer_rom_path).parent_path().filename().string();
+
+    Libretro::environ_cb(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY, &gba_save_dir);
+    std::filesystem::path base = std::filesystem::path(gba_save_dir);
+
+    bool core_sort = false;
+    retro_system_info sys_info{};
+    retro_get_system_info(&sys_info);
+    const std::string library_name = sys_info.library_name;
+
+    if (!base.empty() && !library_name.empty())
+      core_sort = Common::CaseInsensitiveEquals(base.filename().string(), library_name);
+    if (core_sort)
+      base = base.parent_path();
+
+    bool content_sort = false;
+    std::string gc_content_dir;
+    if (!gba_content_dir.empty() && !base.empty())
+      content_sort = Common::CaseInsensitiveEquals(base.filename().string(), gba_content_dir.string());
+    if (content_sort)
+    {
+      gc_content_dir = std::filesystem::path(game->path).parent_path().filename().string();
+      base = base.parent_path();
+    }
+
+    rebuild_save_dir = base.string();
+    if (content_sort)
+      rebuild_save_dir = rebuild_save_dir + DIR_SEP + gc_content_dir;
+    if (core_sort)
+      rebuild_save_dir = rebuild_save_dir + DIR_SEP + library_name;
+
+    save_dir = rebuild_save_dir.c_str();
+    INFO_LOG_FMT(BOOT, "GBPlayer: GC save dir reconstructed to: '{}'", save_dir);
+  }
+  else
+  {
+    Libretro::environ_cb(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY, &save_dir);
+  }
+
   Libretro::environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &system_dir);
   Libretro::environ_cb(RETRO_ENVIRONMENT_GET_CORE_ASSETS_DIRECTORY, &core_assets_dir);
   Libretro::InitDiskControlInterface();
@@ -212,6 +270,22 @@ bool retro_load_game(const struct retro_game_info* game)
   UICommon::CreateDirectories();
   UICommon::Init();
   Libretro::Log::Init();
+
+  if (Libretro::GBPlayer_active)
+  {
+    Config::SetBase(Config::MAIN_GBA_ROM_PATHS[Config::GBPLAYER_GBA_INDEX], Libretro::GBPlayer_rom_path);
+    INFO_LOG_FMT(BOOT, "GBPlayer: GBA ROM path applied from subsystem: '{}'", Libretro::GBPlayer_rom_path);
+    Config::SetBase(Config::MAIN_GBA_SAVES_PATH, std::string(gba_save_dir));
+    INFO_LOG_FMT(BOOT, "GBPlayer: ROM save set to: '{}'", gba_save_dir);
+    // In order to prevent confusion for the settings of the save location between RA and the
+    // emulator we just turn this off
+    Config::SetBase(Config::MAIN_GBA_SAVES_IN_ROM_PATH, false);
+  }
+  else
+  {
+    Config::SetBase(Config::MAIN_GBA_ROM_PATHS[Config::GBPLAYER_GBA_INDEX], std::string{});
+  }
+
   Discord::SetDiscordPresenceEnabled(false);
   Common::SetEnableAlert(false);
   Common::SetAbortOnPanicAlert(false);
@@ -621,10 +695,44 @@ bool retro_load_game(const struct retro_game_info* game)
   return true;
 }
 
-bool retro_load_game_special(unsigned game_type, const struct retro_game_info* info,
-                             size_t num_info)
+bool retro_load_game_special(unsigned game_type, const struct retro_game_info* info, size_t num_info)
 {
-  return false;
+  if (game_type != Libretro::g_gbplayer_subsystem_id)
+  {
+    ERROR_LOG_FMT(BOOT, "retro_load_game_special: unknown game_type {}", game_type);
+    return false;
+  }
+  if (num_info < 1 || !info)
+  {
+    ERROR_LOG_FMT(BOOT, "retro_load_game_special: no content info");
+    return false;
+  }
+
+  const retro_game_info* gba_slot = (num_info >= 2 && info[0].path && *info[0].path) ? &info[0] : nullptr;
+
+  const retro_game_info* gc_slot = (info[1].path && *info[1].path) ? &info[1] : nullptr;
+
+  if (!gc_slot)
+  {
+    ERROR_LOG_FMT(BOOT, "GBPlayer: no GC disc path provided in slot 0");
+    return false;
+  }
+
+  INFO_LOG_FMT(BOOT, "GBPlayer: GC disc  = '{}'", gc_slot->path);
+  if (gba_slot)
+  {
+    Libretro::GBPlayer_rom_path = gba_slot->path;
+    INFO_LOG_FMT(BOOT, "GBPlayer: ROM = '{}'", gba_slot->path);
+  }
+  else
+  {
+    Libretro::GBPlayer_rom_path.clear();
+    INFO_LOG_FMT(BOOT, "GBPlayer: no ROM");
+  }
+
+  Libretro::GBPlayer_active = true;
+
+  return retro_load_game(gc_slot);
 }
 
 void retro_unload_game(void)

--- a/Source/Core/DolphinLibretro/Common/Globals.h
+++ b/Source/Core/DolphinLibretro/Common/Globals.h
@@ -13,6 +13,7 @@ extern retro_environment_t environ_cb;
 extern bool g_emuthread_launched;
 extern std::vector<Gecko::GeckoCode> g_gecko_codes;
 extern std::vector<ActionReplay::ARCode> g_ar_codes;
+inline constexpr unsigned g_gbplayer_subsystem_id = 0x101;
 
 namespace Input
 {

--- a/Source/Core/DolphinLibretro/Main.cpp
+++ b/Source/Core/DolphinLibretro/Main.cpp
@@ -86,6 +86,30 @@ void retro_set_environment(retro_environment_t cb)
 #ifdef PERF_TEST
   environ_cb(RETRO_ENVIRONMENT_GET_PERF_INTERFACE, &perf_cb);
 #endif
+static const struct retro_subsystem_memory_info gbp_gba_memory[] = {
+  {"srm", RETRO_MEMORY_SAVE_RAM},
+};
+static const struct retro_subsystem_rom_info gbp_roms[] = {
+  {"GBA ROM", "gba|gbc|gb|zip|7z",
+    true,
+    true,
+    false,
+    gbp_gba_memory, 1},
+  {"GameCube Disc", "rvz|gcm|iso|ciso|wbfs|gcz|tgc|m3u",
+    true,
+    false,
+    true,
+    nullptr, 0},
+};
+static const struct retro_subsystem_info subsystems[] = {
+  {
+    "Game Boy Player",
+    "GBP",
+    gbp_roms, 2,
+    Libretro::g_gbplayer_subsystem_id
+  },
+  {nullptr, nullptr, nullptr, 0, 0}};
+cb(RETRO_ENVIRONMENT_SET_SUBSYSTEM_INFO, (void*)subsystems);
 }
 
 void retro_init(void)


### PR DESCRIPTION
@cscd98 Would you mind taking a look at my PR and give feedback before I remove the draft flag? I believe you are the maintainer of this core now and feedback of the decision would greatly help getting it over the finish line.

This is an implementation of the Subsystem menu of Retroarch for the Game Boy Player in the Dolphin Emulator core.

It has a simple menu under 'Load Content' to select both the ROM and the GBPlayer disc in order to play the GB\GBC\GBA game on a Game Cube similar to how bSNES does it with the Super Game Boy.

The ROM is set to be the primary content and the GC disc as secondary as per the guidelines of Retroarch.

There are 2 points that do need to be discussed:

- This core now saves 2 types of content instead of one. A ROM save for the game played as well as a User directory with GC save for the settings of the Game Boy Player. If sorting is enabled, the ROM save will simply use the settings to set that path correctly as it is the primary content. If nothing is done, the GC save will end up there as well and I try to address it in the DolphinLibretro\Boot.cpp. I understand that I am trying to solve frontend issues in a core, but currently there is no other way to have both saves end up where they should as the Subsystem currently only provides 1 save path and since this is a multi-system core, it is not too farfetched to think that users have set save sorting enabled for it.

- In HW\GBACore.cpp I have edited the save location line from
`std::string save_path = fmt::format("{}-{}.sav", rom_path.substr(0, rom_path.find_last_of('.')), device_number + 1);
` to `std::string save_path = fmt::format("{}.srm", rom_path.substr(0, rom_path.find_last_of('.')));`
The reason for that is so that the GBPlayer reads the save files of the mGBA core as dolphin implemented mGBA as their emulator for GB\GBC\GBA content. I understand that this changes source code in the actual emulator instead of the Retroarch implementation of it but I see no other way to make it read *.srm saves the mGBA core makes. It is only one line and provides real benefit as by doing this, Retroarch provides a way to play GB\GBC\GBA ROMs through all types of Game Boy hardware:
GB,GBC,GBA,SGB,SGB2,GBP with complete save compatibility. This in my opinion is the true value that Retroarch provides over standalone emulators. If there is a way to implement *.srm save compatibility from the Retroarch side of things, please provide guidance for it. No conversion is needed from the change of *.sav to *.srm in these cases as they are identical.

While testing do note that there is a bug with the Subsystems in Retroarch. When loading Subsystem content through the Retroarch menu that is not in an archive, content directory and game specific overrides do not get applied. This is because the field that sets the content info is not filled by the time it is requested in Retroarch\runloop.c. This was tested in bSNES with SGB and the issue is prevalent there as well. The issue with the bug is that if a user has content directory overrides for their system folder, the GBPlayer will not boot at all as it cannot find the *.ini to set the hardware even when the user has done everything correctly setup wise. Here are 3 runs of the dolphin core with Subsystems implemented, one run with the stable release, one run with the latest code and one run with the edit provided below. Note that these bugs are not in question when loading from CLI or when loading an archived ROM with a default bios location (in the case of bSNES).
[Edit.log](https://github.com/user-attachments/files/29963969/Edit.log)
[Latest.log](https://github.com/user-attachments/files/29963970/Latest.log)
[Stable release.log](https://github.com/user-attachments/files/29963973/Stable.release.log)



This should fix it, add it in Retroarch\runloop.c, function: runloop_event_init_core, around line 4881:

```
if (!sys_info->info.valid_extensions)
   strlcpy(sys_info->valid_extensions, DEFAULT_EXT,
         sizeof(sys_info->valid_extensions));

   //Add this line right here
   content_set_subsystem_info();

#ifdef HAVE_CONFIGFILE
   if (auto_overrides_enable)
      config_load_override(&runloop_st->system);
#endif
```

The thing is, since this is a front end bug and not a dolphin core bug, I am hesitant to push it as this will cause loading behaviour change for all cores using the Subsystem menu in Retroarch which in turn will have a lot of edge cases + users may already have working solutions build around it which could also break by it.

All in all, it really wasn't as easy as I hoped it would be but I do hope we can get this up and running in the core and let people play GBPlayer in Retroarch.