### PR TITLE
Libretro: fix launch hang on devices with Vulkan swapchains that have more than eight images

### DIFF
--- a/Source/Core/DolphinLibretro/Vulkan.cpp
+++ b/Source/Core/DolphinLibretro/Vulkan.cpp
@@ -77,16 +77,17 @@ static struct
 } initInfo;
 static bool DEDICATED_ALLOCATION;
 
-#define VULKAN_MAX_SWAPCHAIN_IMAGES 8
+struct VkSwapchainImage
+{
+  VkImage handle;
+  VkDeviceMemory memory;
+  retro_vulkan_image retro_image;
+};
+
 struct VkSwapchainKHR_T
 {
   uint32_t count;
-  struct
-  {
-    VkImage handle;
-    VkDeviceMemory memory;
-    retro_vulkan_image retro_image;
-  } images[VULKAN_MAX_SWAPCHAIN_IMAGES];
+  std::vector<VkSwapchainImage> images;
   std::mutex mutex;
   std::condition_variable condVar;
   int current_index;
@@ -270,7 +271,7 @@ vkCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR* pCreateInf
     chain.count++;
     swapchain_mask >>= 1;
   }
-  assert(chain.count <= VULKAN_MAX_SWAPCHAIN_IMAGES);
+  chain.images.resize(chain.count);
 
   for (uint32_t i = 0; i < chain.count; i++)
   {
@@ -448,7 +449,7 @@ static VKAPI_ATTR void VKAPI_CALL vkDestroySwapchainKHR(VkDevice device, VkSwapc
     vkFreeMemory(device, chain.images[i].memory, pAllocator);
   }
 
-  memset(&chain.images, 0x00, sizeof(chain.images));
+  chain.images.clear();
   chain.count = 0;
   chain.current_index = -1;
 }


### PR DESCRIPTION
## Problem

The libretro Vulkan shim stores its fake swapchain images in a fixed eight-element array.

RetroArch now supports swapchains with up to 16 images ([libretro/RetroArch#19186](https://github.com/libretro/RetroArch/pull/19186)), which exposed this core-side limit on drivers that return more than eight images.

When that happens, Dolphin writes past the fixed array while creating the fake swapchain. In release builds, this corrupts adjacent state, including synchronization objects, and hangs on booting a game.

## Fix

Replace the fixed image array with dynamically sized storage based on the frame-slot mask reported by the frontend. This preserves the existing fake-swapchain behavior while removing the unsupported eight-image limit.

## Validation

- Android libretro build passed.
- Tested Vulkan on RG477M - Android 14 / Mali with RetroArch.