### PR TITLE
libretro: enable VFS by default on Android due to SAF

### DIFF
--- a/Source/Core/DolphinLibretro/Common/Options.cpp
+++ b/Source/Core/DolphinLibretro/Common/Options.cpp
@@ -1772,7 +1772,11 @@ static struct retro_core_option_v2_definition option_defs[] = {
       { "enabled",  nullptr },
       { nullptr, nullptr }
     },
+#if defined(ANDROID)
+    "enabled" // enable by default because of SAF
+#else
     "disabled"
+#endif
   },
 
   { nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, {{0}}, nullptr }


### PR DESCRIPTION
SAF means you cannot launch dolphin in the first instance to enable VFS, so we enable it by default for Android.