### PR TITLE
ci: add Linux aarch64 libretro build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,11 @@ include:
   # Linux 64-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-cmake.yml'
-    
+
+  # Linux ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-cmake-aarch64.yml'
+
   # MacOS x64
   - project: 'libretro-infrastructure/ci-templates'
     file: 'osx-cmake-x86.yml'
@@ -72,6 +76,18 @@ libretro-build-linux-x64:
     - .libretro-linux-cmake-x86_64
     - .core-defs
   image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-amd64-ubuntu:backports
+  variables:
+    CC: /usr/bin/gcc-12
+    CXX: /usr/bin/g++-12
+
+# Linux ARM 64-bit
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-cmake-aarch64
+    - .core-defs
+  # Same as the x64 job: the default image's GCC is too old for this core's
+  # C++ usage, so use the backports image and GCC 12.
+  image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-aarch64-ubuntu:backports
   variables:
     CC: /usr/bin/gcc-12
     CXX: /usr/bin/g++-12

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,10 +22,6 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-cmake.yml'
 
-  # Linux ARM 64-bit
-  - project: 'libretro-infrastructure/ci-templates'
-    file: '/linux-cmake-aarch64.yml'
-
   # MacOS x64
   - project: 'libretro-infrastructure/ci-templates'
     file: 'osx-cmake-x86.yml'
@@ -85,9 +81,9 @@ libretro-build-linux-aarch64:
   extends:
     - .libretro-linux-cmake-aarch64
     - .core-defs
-  # Same as the x64 job: the default image's GCC is too old for this core's
-  # C++ usage, so use the backports image and GCC 12.
-  image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-aarch64-ubuntu:backports
+  # No image override: unlike the x64 image, the aarch64 one already ships GCC 12
+  # (from ppa:ubuntu-toolchain-r/test in its Dockerfile), and it has no
+  # :backports tag at all.
   variables:
     CC: /usr/bin/gcc-12
     CXX: /usr/bin/g++-12


### PR DESCRIPTION
Adds a `libretro-build-linux-aarch64` job so the core is built for Linux aarch64 on the buildbot (there is currently no Linux aarch64 nightly for dolphin).

The core already compiles for aarch64 via the existing `android-arm64-v8a` job (JitArm64, ARM64 FFmpeg, etc.), and the CMake build handles `aarch64` correctly (sets `_M_ARM_64`, ARM64 output paths). This job simply reuses the same CMake path with GCC 12 on the aarch64 backports image, mirroring the existing `libretro-build-linux-x64` job (same `-DLIBRETRO=ON -DENABLE_LTO=ON` args).

### Verified locally

Built on aarch64 Linux (postmarketOS, glibc, GCC 15) with `-DLIBRETRO=ON`, producing a 19.4 MB `dolphin_libretro.so` with no errors. I had to build with `-DENABLE_LTO=OFF` because the LTO link OOMs on my 3.8 GB test device; the CI runners have the headroom, so the job keeps the default `-DENABLE_LTO=ON` to match the x64 job.

Runtime check on the resulting core (RetroArch 1.22.2, Adreno 618 / Mesa freedreno + Turnip): Mario Kart: Double Dash!! boots and renders at **60 fps** with JitArm64 and the OGL backend. The Vulkan backend also negotiates its HW render context without errors.

### Unrelated pre-existing bug found while testing

Not caused by this PR, but worth flagging: on aarch64 the default option combination **`dolphin_cpu_core = JITARM64` + `dolphin_main_cpu_thread = enabled` deadlocks** — black screen and the frontend's main loop stops responding entirely (RetroArch does not even react to a network `QUIT` command). Reproduced 3/3. Changing either one of the two resolves it:

* `dolphin_cpu_core = JITARM64` + `dolphin_main_cpu_thread = disabled` -> 60 fps
* `dolphin_cpu_core = Cached Interpreter` + `dolphin_main_cpu_thread = enabled` -> ~17 fps

So it appears to be an interaction between JitArm64 and the separate CPU thread rather than a fault in either on its own. I can open a separate issue with logs if that is useful.