### PR TITLE
libretro: add armv7a android for play, enable VFS by default on webOS…

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -114,6 +114,16 @@ android-arm64-v8a:
     ANDROID_NDK_VERSION: 29.0.14206865
     NDK_ROOT: /android-sdk-linux/ndk/$ANDROID_NDK_VERSION
 
+# Android ARMv7a
+android-armv7a:
+  extends:
+    - .libretro-android-cmake-armeabi-v7a
+    - .core-defs
+  variables:
+    ANDROID_NDK_VERSION: 29.0.14206865
+    NDK_ROOT: /android-sdk-linux/ndk/$ANDROID_NDK_VERSION
+    CORE_ARGS: "$CORE_ARGS -DENABLE_GENERIC=ON"
+
 # iOS arm64
 libretro-build-ios-arm64:
   extends:

--- a/Source/Core/DolphinLibretro/Common/Options.cpp
+++ b/Source/Core/DolphinLibretro/Common/Options.cpp
@@ -1772,8 +1772,8 @@ static struct retro_core_option_v2_definition option_defs[] = {
       { "enabled",  nullptr },
       { nullptr, nullptr }
     },
-#if defined(ANDROID)
-    "enabled" // enable by default because of SAF
+#if defined(ANDROID) || defined(__WEBOS__)
+    "enabled" // enable by default because of SAF (android play version) / storage (webOS)
 #else
     "disabled"
 #endif


### PR DESCRIPTION
… too

1. add armv7a android (no JIT).. to satisfy google
2. enable VFS by default on webOS