### PR TITLE
OGL: do not call glMemoryBarrier when ARB_shader_image_load_store is missing

### DIFF
--- a/Source/Core/VideoBackends/OGL/OGLBoundingBox.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLBoundingBox.cpp
@@ -5,6 +5,7 @@
 
 #include <cstring>
 
+#include "VideoBackends/OGL/OGLConfig.h"
 #include "VideoBackends/OGL/OGLGfx.h"
 #include "VideoCommon/DriverDetails.h"
 
@@ -37,7 +38,7 @@ std::vector<BBoxType> OGLBoundingBox::Read(u32 index, u32 length)
   // on nVidia drivers. This is more noticeable at higher internal resolutions.
   // Using glGetBufferSubData instead does not seem to exhibit this slowdown.
   if (!DriverDetails::HasBug(DriverDetails::BUG_SLOW_GETBUFFERSUBDATA) &&
-      !static_cast<OGLGfx*>(g_gfx.get())->IsGLES())
+      !static_cast<OGLGfx*>(g_gfx.get())->IsGLES() && g_ogl_config.bSupportsImageLoadStore)
   {
     // We also need to ensure the the CPU does not receive stale values which have been updated by
     // the GPU. Apparently the buffer here is not coherent on NVIDIA drivers. Not sure if this is a


### PR DESCRIPTION
Fixes #466.

`OGLBoundingBox::Read` calls `glMemoryBarrier` on the non-GLES path, but that
entry point comes from ARB_shader_image_load_store. On a desktop context below
GL 4.2 the pointer is null, while `bSupportsBBox` can still be true because it
is set from `bSupportsFragmentStoresAndAtomics`. Saving a state reads the
bounding box and calls the null pointer.

This adds `bSupportsImageLoadStore` to the condition, the same check
`UsePersistentStagingBuffers()` in OGLTexture.cpp already uses for that
function. Drivers without it fall to the `glMapBufferRange` path below.

Tested on Mesa v3d (Raspberry Pi 5, GL 3.1), where saving a state segfaulted
every time and now saves and loads a 55 MB state repeatedly. I have no other
GL 3.1 hardware to check it against.
