### PR TITLE
libretro: add Wiimote IR passthrough

### DIFF
--- a/Source/Core/DolphinLibretro/Common/Options.cpp
+++ b/Source/Core/DolphinLibretro/Common/Options.cpp
@@ -1715,6 +1715,20 @@ static struct retro_core_option_v2_definition option_defs[] = {
     },
     "disabled"
   },
+  {
+    Libretro::Options::wiimote::IR_PASSTHROUGH,
+    "Wiimote IR > Wiimote IR Passthrough",
+    "Wiimote IR Passthrough",
+    "Take the Wiimote camera's view of the sensor bar straight from the frontend, instead of deriving it from a cursor position. The frontend supplies up to four IR objects on pointer indices 1-4; Wiimote IR Mode, Total Yaw, Total Pitch and Vertical Offset are all bypassed. For frontends that know the real geometry (a VR room, a tracked light gun) this is exact, and it carries roll and distance, which a cursor cannot. Leave off for a mouse or a gamepad.",
+    nullptr,
+    CATEGORY_WIIMOTE,
+    {
+      { "disabled", nullptr },
+      { "enabled",  nullptr },
+      { nullptr, nullptr }
+    },
+    "disabled"
+  },
 
 #if defined(HAS_OPENGL) && defined(__WEBOS__)
   {

--- a/Source/Core/DolphinLibretro/Common/Options.h
+++ b/Source/Core/DolphinLibretro/Common/Options.h
@@ -302,6 +302,7 @@ namespace wiimote {
   constexpr const char IR_MODIFIER[] = "dolphin_ir_modifier";
   constexpr const char SWING_MODIFIER[] = "dolphin_swing_modifier";
   constexpr const char SWING_ANGLE[] = "dolphin_swing_angle";
+  constexpr const char IR_PASSTHROUGH[] = "dolphin_ir_passthrough";
 }  // namespace wiimote
 
 // ======================================================

--- a/Source/Core/DolphinLibretro/Input.cpp
+++ b/Source/Core/DolphinLibretro/Input.cpp
@@ -38,6 +38,7 @@
 #include "InputCommon/ControlReference/ExpressionParser.h"
 #include "InputCommon/ControllerEmu/Control/Control.h"
 #include "InputCommon/ControllerEmu/ControlGroup/Attachments.h"
+#include "InputCommon/ControllerEmu/ControlGroup/IRPassthrough.h"
 #include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "InputCommon/GCAdapter.h"
@@ -407,11 +408,22 @@ Device::Device(unsigned device, unsigned p) : m_device(device), m_port(p)
     AddButton(RETRO_DEVICE_ID_MOUSE_BUTTON_5, "Button5");
     return;
   case RETRO_DEVICE_POINTER:
-    AddButton(RETRO_DEVICE_ID_POINTER_PRESSED, "Pressed0", 0);
-    AddAxis(RETRO_DEVICE_ID_POINTER_X, -0x8000, "X0-", 0);
-    AddAxis(RETRO_DEVICE_ID_POINTER_X, 0x7FFF, "X0+", 0);
-    AddAxis(RETRO_DEVICE_ID_POINTER_Y, -0x8000, "Y0-", 0);
-    AddAxis(RETRO_DEVICE_ID_POINTER_Y, 0x7FFF, "Y0+", 0);
+    // Four touch indices, one per IR object. Index 0 keeps its old names.
+    {
+      static const char* const kPressed[] = { "Pressed0", "Pressed1", "Pressed2", "Pressed3" };
+      static const char* const kXNeg[]    = { "X0-", "X1-", "X2-", "X3-" };
+      static const char* const kXPos[]    = { "X0+", "X1+", "X2+", "X3+" };
+      static const char* const kYNeg[]    = { "Y0-", "Y1-", "Y2-", "Y3-" };
+      static const char* const kYPos[]    = { "Y0+", "Y1+", "Y2+", "Y3+" };
+      for (unsigned i = 0; i < 4; ++i)
+      {
+        AddButton(RETRO_DEVICE_ID_POINTER_PRESSED, kPressed[i], i);
+        AddAxis(RETRO_DEVICE_ID_POINTER_X, -0x8000, kXNeg[i], i);
+        AddAxis(RETRO_DEVICE_ID_POINTER_X, 0x7FFF, kXPos[i], i);
+        AddAxis(RETRO_DEVICE_ID_POINTER_Y, -0x8000, kYNeg[i], i);
+        AddAxis(RETRO_DEVICE_ID_POINTER_Y, 0x7FFF, kYPos[i], i);
+      }
+    }
     return;
   case RETRO_DEVICE_KEYBOARD:
     return;
@@ -943,6 +955,37 @@ void UpdateWiimoteMappings(const WiimoteUpdateFlags& f, unsigned port, unsigned 
       const int irDeadzone = Libretro::Options::GetCached<int>(Libretro::Options::wiimote::IR_DEADZONE);
       static_cast<ControllerEmu::NumericSetting<double>*>(wmIR->numeric_settings[0].get())
         ->SetValue(irDeadzone); // IR DeadZone
+    }
+  }
+
+  // Raw IR: the frontend supplies the camera's view directly, bypassing the
+  // Point group and Total Yaw/Pitch. Objects arrive on pointer indices 0-3,
+  // X/Y over the camera's 0..1 field, PRESSED marking the object visible.
+  // Size is a constant; games only read it to reject noise.
+  if (f.irPassthrough)
+  {
+    auto* wmIRPass = static_cast<ControllerEmu::IRPassthrough*>(
+      wm->GetWiimoteGroup(WiimoteEmu::WiimoteGroup::IRPassthrough));
+    const bool passthrough =
+      Libretro::Options::GetCached<bool>(Libretro::Options::wiimote::IR_PASSTHROUGH);
+
+    if (wmIRPass)
+    {
+      const std::string devPointer =
+        Libretro::Input::GetQualifiedName(port, RETRO_DEVICE_POINTER);
+      wmIRPass->enabled.SetValue(passthrough);
+      static const char* const kObj[] = { "0", "1", "2", "3" };
+      for (int i = 0; i < 4; ++i)
+      {
+        // Cleared when off; AreInputsBound() is half of what selects this path.
+        const std::string idx = kObj[i];
+        wmIRPass->SetControlExpression(i * 3 + 0,
+          passthrough ? "`" + devPointer + ":X" + idx + "+`" : "");
+        wmIRPass->SetControlExpression(i * 3 + 1,
+          passthrough ? "`" + devPointer + ":Y" + idx + "+`" : "");
+        wmIRPass->SetControlExpression(i * 3 + 2,
+          passthrough ? "`" + devPointer + ":Pressed" + idx + "` * 0.2" : "");
+      }
     }
   }
 
@@ -1516,6 +1559,8 @@ void retro_set_controller_port_device_wii(unsigned port, unsigned device)
     f.irModifier = true;
     f.swingModifier = true;
     f.sideways = true;
+    // Raised at setup so the option applies on a cold boot.
+    f.irPassthrough = true;
     Libretro::Input::UpdateWiimoteMappings(f, port, device);
 
     wmShake->SetControlExpression(0, bindMouse("L2", devMouse + ":Middle"));  // Wiimote shake X

--- a/Source/Core/DolphinLibretro/Input.h
+++ b/Source/Core/DolphinLibretro/Input.h
@@ -19,11 +19,12 @@ struct WiimoteUpdateFlags
     bool sideways      = false;
     bool rumble        = false;
     bool gcMicBtn      = false;
+    bool irPassthrough = false;
 
     bool any() const {
         return irMode || irOffset || irYaw || irPitch ||
                irDeadzone || irModifier || swingModifier ||
-               swingAngle || sideways || rumble || gcMicBtn;
+               swingAngle || sideways || rumble || gcMicBtn || irPassthrough;
     }
 };
 

--- a/Source/Core/DolphinLibretro/Main.cpp
+++ b/Source/Core/DolphinLibretro/Main.cpp
@@ -389,6 +389,7 @@ void retro_run(void)
     flags.swingModifier = Libretro::Options::IsUpdated(Libretro::Options::wiimote::SWING_MODIFIER);
     flags.swingAngle = Libretro::Options::IsUpdated(Libretro::Options::wiimote::SWING_ANGLE);
     flags.sideways = Libretro::Options::IsUpdated(Libretro::Options::wiimote::HOTKEY_SIDEWAYS_TOGGLE);
+    flags.irPassthrough = Libretro::Options::IsUpdated(Libretro::Options::wiimote::IR_PASSTHROUGH);
   }
 
   flags.rumble = Libretro::Options::IsUpdated(Libretro::Options::sysconf::ENABLE_RUMBLE);


### PR DESCRIPTION
Adds dolphin_ir_passthrough, letting the frontend supply the Wiimote camera's view of the sensor bar directly instead of having the core synthesise it from a cursor position.

The cursor path cannot be made exact, and it is worth saying why. It parks a notional remote two metres from the bar and rotates it by Total Yaw / Total Pitch, a scale with no physical derivation, then CameraLogic projects the LEDs through that. Where the game finally draws its hand therefore depends on a constant fitted per game, which is what Dolphin's own "defaults chosen to reach screen edges in most games" is admitting. It also cannot express roll or distance at all: two angles have nowhere to put them.

A frontend that knows the real geometry, a VR room, a tracked light gun , can compute the two dots outright and get all of that for free, which is what BuildDesiredWiimoteState already supports and nothing exposed.

Four pieces:

  * The option itself, off by default, under Wiimote IR.

  * The Pointer device now registers all four touch indices rather than only the first. libretro's pointer is multi-touch already, so the four IR objects ride on indices 0-3 instead of needing a new device type. Index 0 keeps the names it had, so the existing mouse-mode IR binding is untouched.

  * IRPassthrough is bound and enabled when the option is on: object N takes Pointer:XN+ / Pointer:YN+ across the camera's 0..1 field (so a frontend sends the positive half of the pointer range), with PressedN as presence and a small constant size, games read size to reject noise, and there is no spare axis to carry it. Bindings are CLEARED when the option is off, because AreInputsBound() is half of what selects this path and a stale binding would keep the cursor route switched off after it was turned back on.

  * irPassthrough is raised at controller setup as well as on an option change, so the setting applies on a cold boot. The IR offset, yaw and pitch settings are gated on IsUpdated alone, which means their declared defaults never reach the emulated remote until something moves them, a trap this option should not inherit.