### PR TITLE
libretro: fix path for some games like MM9 on windows when using mingw

### DIFF
--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -849,7 +849,7 @@ std::u16string UTF8ToUTF16(std::string_view input)
 // This is a replacement for path::u8path, which is deprecated starting with C++20.
 std::filesystem::path StringToPath(std::string_view path)
 {
-#ifdef _MSC_VER
+#ifdef _WIN32
   return std::filesystem::path(UTF8ToWString(path));
 #else
   return std::filesystem::path(path);


### PR DESCRIPTION
Otherwise games crashes with:

```
#35 0x00007ff87ba6e28d in IOS::HLE::FS::HostFileSystem::OpenFile (this=0x4176d240, path=..., mode=IOS::HLE::FS::Mode::Read) at C:/Users/xx/Developer/dolphin/Source/Core/Core/IOS/FS/HostBackend/File.cpp:85
        handle = 0x4176d328
--Type <RET> for more, q to quit, c to continue without paging--
        host_path = {_M_dataplus = {<std::allocator<char>> = {<std::__new_allocator<char>> = {<No data fields>}, <No data fields>}, _M_p = 0x3ad0d3f0 "C:/RetroArch-Win64/saves/dolphin-emu/User/Wii/title/00010001/57523950/data\201¡\200\200P/ec.cfg"},
```