### PR TITLE
libretro: use libretro callbacks to show errors to the user instead of OSD

### DIFF
--- a/Source/Core/DolphinLibretro/Boot.cpp
+++ b/Source/Core/DolphinLibretro/Boot.cpp
@@ -294,6 +294,7 @@ bool retro_load_game(const struct retro_game_info* game)
   {
     // Log the message instead of showing a popup
     WARN_LOG_FMT(COMMON, "Suppressed popup: {} - {}", caption, text);
+    Libretro::Log::LogFrontEnd(style, caption, text, 2000);
     return true; // Always "continue"
   });
 
@@ -305,10 +306,28 @@ bool retro_load_game(const struct retro_game_info* game)
 
   if (!File::Exists(codehandler))
   {
-    OSD::AddMessage(fmt::format("Core file {} missing! Go to Online Updater ->\nCore System Files Downloader -> Install Dolphin.zip. Restart core to take affect",
-      GECKO_CODE_HANDLER), OSD::Duration::VERY_LONG, OSD::Color::RED);
-    ERROR_LOG_FMT(BOOT, "Core file {} missing! Go to Online Updater -> Core System Files Downloader -> Install Dolphin.zip",
-      GECKO_CODE_HANDLER);
+#if defined(ANDROID) || defined(IPHONEOS)
+    // for reduced area to display the message..
+    const std::string missing_core_files_msg =
+      fmt::format(
+        "IMPORTANT - Open Online Updater ->\n"
+        "Core System Files Downloader -> Dolphin.zip.");
+#else
+    const std::string missing_core_files_msg =
+      fmt::format(
+        "Core file {} missing! Open Online Updater ->\n"
+        "Core System Files Downloader -> Install Dolphin.zip. "
+        "Restart core to take effect.",
+        GECKO_CODE_HANDLER);
+#endif
+
+    //OSD::AddMessage(missing_core_files_msg, OSD::Duration::VERY_LONG, OSD::Color::RED);
+
+    Libretro::Log::LogFrontEnd(
+      Common::Log::LogLevel::LERROR, missing_core_files_msg.c_str(),
+      OSD::Duration::VERY_LONG);
+
+    ERROR_LOG_FMT(BOOT, "{}", missing_core_files_msg);
   }
 
   // Main.Core

--- a/Source/Core/DolphinLibretro/Log.cpp
+++ b/Source/Core/DolphinLibretro/Log.cpp
@@ -10,6 +10,7 @@
 namespace Libretro
 {
 extern retro_environment_t environ_cb;
+unsigned msg_interface_version = 0;
 namespace Log
 {
 class LogListener : public Common::Log::LogListener
@@ -129,5 +130,88 @@ void LogListener::Log(Common::Log::LogLevel level, const char* text)
   __android_log_print(ANDROID_LOG_INFO, "DolphinEmuLibretro", "%s", text);
 #endif
 }
+
+retro_log_level GetRetroLogLevel(Common::Log::LogLevel level)
+{
+  switch(level)
+  {
+    case Common::Log::LogLevel::LNOTICE:
+      return retro_log_level::RETRO_LOG_INFO;
+    case Common::Log::LogLevel::LERROR:
+      return retro_log_level::RETRO_LOG_ERROR;
+    case Common::Log::LogLevel::LWARNING:
+      return retro_log_level::RETRO_LOG_WARN;
+    case Common::Log::LogLevel::LINFO:
+      return retro_log_level::RETRO_LOG_INFO;
+    case Common::Log::LogLevel::LDEBUG:
+      return retro_log_level::RETRO_LOG_DEBUG;
+  }
+
+  return retro_log_level::RETRO_LOG_INFO;
+}
+
+retro_log_level GetRetroLogLevelForMsgType(Common::MsgType level)
+{
+  switch(level)
+  {
+    case Common::MsgType::Information:
+      return retro_log_level::RETRO_LOG_INFO;
+    case Common::MsgType::Question:
+      return retro_log_level::RETRO_LOG_INFO;
+    case Common::MsgType::Warning:
+      return retro_log_level::RETRO_LOG_WARN;
+    case Common::MsgType::Critical:
+      return retro_log_level::RETRO_LOG_ERROR;
+  }
+
+  return retro_log_level::RETRO_LOG_INFO;
+}
+
+void DoLogFrontEnd(retro_log_level level, const char* text, unsigned int duration)
+{
+  if (msg_interface_version >= 1)
+  {
+    struct retro_message_ext message = {
+        text,
+        duration,
+        3, // priority
+        level,
+        RETRO_MESSAGE_TARGET_ALL,
+        RETRO_MESSAGE_TYPE_NOTIFICATION,
+        -1 // progress
+    };
+
+    environ_cb(RETRO_ENVIRONMENT_SET_MESSAGE_EXT, &message);
+  }
+  else
+  {
+    struct retro_message message = {
+      text,
+      180 // frames
+    };
+
+    environ_cb(RETRO_ENVIRONMENT_SET_MESSAGE, &message);
+  }
+}
+
+void LogFrontEnd(Common::Log::LogLevel level, const char* text, unsigned int duration)
+{
+  DoLogFrontEnd(GetRetroLogLevel(level), text, duration);
+}
+
+void LogFrontEnd(Common::MsgType style, const char* caption, const char* text, unsigned int duration)
+{
+  char message[1024];
+
+  if (text && std::string(text) == "Failed to create shared context for shader compiling.")
+    return; // ignore
+
+  snprintf(message, sizeof(message), "%s - %s",
+         caption ? caption : "",
+         text ? text : "");
+
+  DoLogFrontEnd(GetRetroLogLevelForMsgType(style), message, duration);
+}
+
 }  // namespace Log
 }  // namespace Libretro

--- a/Source/Core/DolphinLibretro/Log.h
+++ b/Source/Core/DolphinLibretro/Log.h
@@ -1,12 +1,19 @@
 #pragma once
 
 #include <libretro.h>
+#include "Common/MsgHandler.h"
 
 namespace Libretro
 {
+extern unsigned msg_interface_version;
 namespace Log
 {
 void Init();
 void Shutdown();
+retro_log_level GetRetroLogLevel(Common::Log::LogLevel level);
+retro_log_level GetRetroLogLevelForMsgType(Common::MsgType level);
+void DoLogFrontEnd(retro_log_level level, const char* text, unsigned int duration);
+void LogFrontEnd(Common::Log::LogLevel level, const char* text, unsigned int duration);
+void LogFrontEnd(Common::MsgType style, const char* caption, const char* text, unsigned int duration);
 }
 }  // namespace Libretro

--- a/Source/Core/DolphinLibretro/Main.cpp
+++ b/Source/Core/DolphinLibretro/Main.cpp
@@ -79,6 +79,7 @@ double g_core_refresh_rate{0};
 // trigger a mode-family reinit, only a real in-game 50<->60 switch should.
 static bool s_refresh_rate_settled = false;
 extern void reload_cheats_from_ini();
+extern unsigned msg_interface_version;
 }  // namespace Libretro
 
 extern "C" {
@@ -119,6 +120,9 @@ void retro_init(void)
 {
   enum retro_pixel_format xrgb888 = RETRO_PIXEL_FORMAT_XRGB8888;
   Libretro::environ_cb(RETRO_ENVIRONMENT_SET_PIXEL_FORMAT, &xrgb888);
+
+  Libretro::environ_cb(RETRO_ENVIRONMENT_GET_MESSAGE_INTERFACE_VERSION,
+    &Libretro::msg_interface_version);
 }
 
 void retro_deinit(void)


### PR DESCRIPTION
OSD isn't readable on phones.

Libretro callbacks should be more readable.

Also now show previously hidden popup errors, instead of just logging to file